### PR TITLE
Proving converse of the equivalence of contextual refinement definitions

### DIFF
--- a/theories/prob/distribution.v
+++ b/theories/prob/distribution.v
@@ -908,7 +908,19 @@ Section bind_lemmas.
     erewrite <-bind_split_sum; first done.
     intros. apply ssd_sum.
   Qed. 
-    
+
+
+  (** *strengthen following lemma? *)
+  Lemma ssd_bind_constant P μ ν (b : B) k:
+    (∀ a, P a = true -> ν a b = k) -> (ssd P μ ≫= λ a', ν a') b = k * SeriesC (ssd P μ).
+  Proof.
+  Admitted.
+
+  Lemma ssd_fix_value μ (v : A):
+    SeriesC (ssd (λ a, bool_decide (a = v)) μ) = μ v.
+  Proof.
+  Admitted.
+  
 End bind_lemmas.
 
 

--- a/theories/prob/distribution.v
+++ b/theories/prob/distribution.v
@@ -890,6 +890,14 @@ Section subset_distribution_lemmas.
   Proof.
     rewrite /ssd /ssd_pmf /pmf /=.
     destruct (P a) => /=; lra.
+  Qed.
+
+  Lemma ssd_remove P μ : (∀ a, negb (P a) -> μ a = 0) -> ssd P μ = μ.
+  Proof.
+    move=> H0.
+    apply distr_ext. move=> a. destruct (P a) eqn:H'.
+    - by rewrite /ssd{1}/pmf/ssd_pmf H'. 
+    - rewrite /ssd{1}/pmf/ssd_pmf H'. rewrite H0; [done|by rewrite H']. 
   Qed. 
 
 End subset_distribution_lemmas.

--- a/theories/program_logic/exec.v
+++ b/theories/program_logic/exec.v
@@ -553,45 +553,9 @@ Section prim_exec_lim.
              apply IHn.
   Qed.
 
-
-
-  
-  (** * strengthen lemma? *)
-  Lemma ssd_fix_value_lim_exec_val_lim_exec_cfg e σ (v : val Λ):
-    SeriesC (ssd (λ '(e', σ'), bool_decide (to_val e' = Some v)) (lim_exec_cfg (e, σ))) =
-    SeriesC (ssd (λ e' : val Λ, bool_decide (e' = v)) (lim_exec_val (e, σ))).
-  Proof.
-    rewrite {2}/ssd {2}/pmf/ssd_pmf.
-    pose (id := λ a: val Λ, a).
-    assert ( SeriesC (λ a : val Λ, if bool_decide (a = v) then lim_exec_val (e, σ) a else 0) =
-      (SeriesC (λ a : val Λ, if bool_decide (id a = v) then lim_exec_val (e, σ) v else 0))). 
-    { f_equal. apply functional_extensionality_dep.
-      intros. rewrite /id. case_bool_decide; by subst. }
-    rewrite H.
-    rewrite SeriesC_singleton_inj; [|eauto]. clear H id.
-    
-    replace (SeriesC _) with
-            (SeriesC (λ σ', lim_exec_cfg (e, σ) (of_val v, σ'))); last first.
-    { erewrite <-(dmap_mass _ (λ s, s.2)). f_equal.
-      apply functional_extensionality_dep.
-      intros.
-      rewrite /dmap.
-      rewrite {2}/pmf/=/dbind_pmf.
-      replace (SeriesC _) with (SeriesC (λ s, if bool_decide (s = (of_val v, x)) then lim_exec_cfg (e, σ) (of_val v, x) else 0)).
-      2: { f_equal. apply functional_extensionality_dep. intros [].
-           case_bool_decide; rewrite /ssd {2}/pmf/=/ssd_pmf; first case_bool_decide.
-           - inversion H. rewrite dret_1_1; [|done]. by rewrite Rmult_1_r.
-           - inversion H. subst. rewrite to_of_val in H0. done.
-           - rewrite /pmf. case_bool_decide.
-             + apply of_to_val in H0. rewrite H0 in H.
-               replace (dret_pmf _ _) with 0; [lra|].
-               assert (s ≠ x); [intro; by subst|].
-               rewrite /dret_pmf. case_bool_decide; [done|lra].
-             + lra. 
-      }
-      rewrite SeriesC_singleton_inj; eauto.
-    }
-    assert ( (λ σ', lim_exec_cfg (e, σ) (of_val v, σ')) = (λ σ', Sup_seq (λ n, exec_cfg n (e, σ) (of_val v, σ')))).
+  Lemma lim_exec_cfg_lim_exec_val_relate e σ v: SeriesC (λ σ', lim_exec_cfg (e, σ) (of_val v, σ')) = lim_exec_val (e, σ) v.
+    Proof. 
+assert ( (λ σ', lim_exec_cfg (e, σ) (of_val v, σ')) = (λ σ', Sup_seq (λ n, exec_cfg n (e, σ) (of_val v, σ')))).
     { apply functional_extensionality_dep. by intros. }
     rewrite H.
     assert (SeriesC (λ σ', Sup_seq (λ n : nat, exec_cfg n (e, σ) (of_val v, σ'))) = Sup_seq (λ n, SeriesC (λ σ', exec_cfg n (e, σ) (of_val v, σ')))).
@@ -672,6 +636,46 @@ Section prim_exec_lim.
         repeat f_equal. apply functional_extensionality_dep.
         intros []. f_equal. apply Rbar_finite_eq. apply IHn.
   Qed. 
+  
+  (** * strengthen lemma? *)
+  Lemma ssd_fix_value_lim_exec_val_lim_exec_cfg e σ (v : val Λ):
+    SeriesC (ssd (λ '(e', σ'), bool_decide (to_val e' = Some v)) (lim_exec_cfg (e, σ))) =
+    SeriesC (ssd (λ e' : val Λ, bool_decide (e' = v)) (lim_exec_val (e, σ))).
+  Proof.
+    rewrite {2}/ssd {2}/pmf/ssd_pmf.
+    pose (id := λ a: val Λ, a).
+    assert ( SeriesC (λ a : val Λ, if bool_decide (a = v) then lim_exec_val (e, σ) a else 0) =
+      (SeriesC (λ a : val Λ, if bool_decide (id a = v) then lim_exec_val (e, σ) v else 0))). 
+    { f_equal. apply functional_extensionality_dep.
+      intros. rewrite /id. case_bool_decide; by subst. }
+    rewrite H.
+    rewrite SeriesC_singleton_inj; [|eauto]. clear H id.
+    
+    replace (SeriesC _) with
+            (SeriesC (λ σ', lim_exec_cfg (e, σ) (of_val v, σ'))); last first.
+    { erewrite <-(dmap_mass _ (λ s, s.2)). f_equal.
+      apply functional_extensionality_dep.
+      intros.
+      rewrite /dmap.
+      rewrite {2}/pmf/=/dbind_pmf.
+      replace (SeriesC _) with (SeriesC (λ s, if bool_decide (s = (of_val v, x)) then lim_exec_cfg (e, σ) (of_val v, x) else 0)).
+      2: { f_equal. apply functional_extensionality_dep. intros [].
+           case_bool_decide; rewrite /ssd {2}/pmf/=/ssd_pmf; first case_bool_decide.
+           - inversion H. rewrite dret_1_1; [|done]. by rewrite Rmult_1_r.
+           - inversion H. subst. rewrite to_of_val in H0. done.
+           - rewrite /pmf. case_bool_decide.
+             + apply of_to_val in H0. rewrite H0 in H.
+               replace (dret_pmf _ _) with 0; [lra|].
+               assert (s ≠ x); [intro; by subst|].
+               rewrite /dret_pmf. case_bool_decide; [done|lra].
+             + lra. 
+      }
+      rewrite SeriesC_singleton_inj; eauto.
+    }
+    apply lim_exec_cfg_lim_exec_val_relate.
+Qed. 
+    
+    
     
   
   Lemma lim_exec_val_exec_det n ρ (v : val Λ) σ :

--- a/theories/program_logic/exec.v
+++ b/theories/program_logic/exec.v
@@ -348,6 +348,7 @@ Section prim_exec_lim.
 
 
   (** * strengthen this lemma? *)
+  
   Lemma lim_exec_bind_continuity_1 e σ ν v:
     (lim_exec_cfg (e, σ) ≫= (λ s, ν s)) v =
     Sup_seq (λ n, (exec_cfg n (e, σ) ≫= (λ s, ν s)) v).
@@ -394,6 +395,7 @@ Section prim_exec_lim.
 
     
   (** * strengthen this lemma? *)
+  
   Lemma lim_exec_bind_continuity_2 (μ : distr (cfg Λ)) v `{!LanguageCtx K}:
     (μ ≫= (λ '(e, σ), lim_exec_val ((K e), σ) )) v =
     Sup_seq (λ n, (μ ≫= (λ '(e, σ), exec_val n ((K e), σ))) v).
@@ -447,6 +449,7 @@ Section prim_exec_lim.
         -- by rewrite {3}/pmf /= /dbind_pmf.
         -- apply pmf_le_1.
   Qed. 
+
   
   Lemma lim_exec_val_context_bind `{!LanguageCtx K} e σ:
     lim_exec_val (K e, σ) =
@@ -551,12 +554,15 @@ Section prim_exec_lim.
   Qed.
 
   (** * strengthen lemma? *)
+
+  
   Lemma ssd_fix_value_lim_exec_val_lim_exec_cfg e σ (v : val Λ):
     SeriesC (ssd (λ '(e', σ'), bool_decide (to_val e' = Some v)) (lim_exec_cfg (e, σ))) =
     SeriesC (ssd (λ e' : val Λ, bool_decide (e' = v)) (lim_exec_val (e, σ))).
   Proof.
   Admitted.
-    
+
+  
   Lemma lim_exec_val_exec_det n ρ (v : val Λ) σ :
     exec n ρ (of_val v, σ) = 1 →
     lim_exec_val ρ = dret v.

--- a/theories/program_logic/exec.v
+++ b/theories/program_logic/exec.v
@@ -177,13 +177,9 @@ Section exec_val.
     rewrite dret_id_left -/exec_cfg.
     fold exec_cfg.
     epose proof (exec_cfg_is_val _ _ _ _ Hv) as Hv'. 
-    destruct Hv.
-    eapply exec_cfg_is_val in Hv as Hv'. erewrite Hv'.
+    erewrite Hv'.
     apply of_to_val in Hv. by subst.
-    Unshelve.
-    - done. 
-    - done.
-  Qed.     
+  Qed.      
   
   Lemma exec_cfg_mon ρ n ρ':
     exec_cfg n ρ ρ' <= exec_cfg (S n) ρ ρ'.
@@ -350,12 +346,17 @@ Section prim_exec_lim.
       intros ??. apply IHn.
   Qed.
 
-  Lemma lim_exec_val_context `{!LanguageCtx K} e σ:
-    lim_exec_cfg (K e, σ) =
-    lim_exec_cfg (e, σ) ≫= λ '(e', σ'), lim_exec_cfg (K e', σ').
+  Lemma lim_exec_val_context_bind `{!LanguageCtx K} e σ:
+    lim_exec_val (K e, σ) =
+    lim_exec_cfg (e, σ) ≫= λ '(e', σ'), lim_exec_val (K e', σ').
   Proof. 
   Admitted.
 
+  Lemma lim_exec_val_relate_cfg e σ v:
+    lim_exec_val (e, σ) v = SeriesC (λ σ', lim_exec_cfg (e,σ) (of_val v, σ')).
+  Proof.
+  Admitted.
+    
   Lemma lim_exec_val_exec_det n ρ (v : val Λ) σ :
     exec n ρ (of_val v, σ) = 1 →
     lim_exec_val ρ = dret v.

--- a/theories/program_logic/exec.v
+++ b/theories/program_logic/exec.v
@@ -351,11 +351,6 @@ Section prim_exec_lim.
     lim_exec_cfg (e, σ) ≫= λ '(e', σ'), lim_exec_val (K e', σ').
   Proof. 
   Admitted.
-
-  Lemma lim_exec_val_relate_cfg e σ v:
-    lim_exec_val (e, σ) v = SeriesC (λ σ', lim_exec_cfg (e,σ) (of_val v, σ')).
-  Proof.
-  Admitted.
     
   Lemma lim_exec_val_exec_det n ρ (v : val Λ) σ :
     exec n ρ (of_val v, σ) = 1 →

--- a/theories/typing/contextual_refinement_alt.v
+++ b/theories/typing/contextual_refinement_alt.v
@@ -460,4 +460,3 @@ Proof.
     rewrite /K' /=. 
     by do 2 rewrite -alt_impl_ctx_refines_loop_lemma.
 Qed. 
-

--- a/theories/typing/contextual_refinement_alt.v
+++ b/theories/typing/contextual_refinement_alt.v
@@ -143,6 +143,12 @@ Proof.
   replace ((e=#b)%E) with (fill_item (BinOpLCtx EqOp (#b)) e); last first.
   { done. }
   rewrite lim_exec_val_context_bind => /=.
+  pose (ν := λ '(e', σ'), lim_exec_val ((e' = #b)%E, σ')).
+  assert ((λ '(e', σ'), lim_exec_val ((e' = #b)%E, σ'))=(λ c, ν c)) as K.
+  { admit. }
+  rewrite K.
+  erewrite (ssd_bind_split_sum _ _ (λ '(e', σ'), bool_decide (to_val e' = Some #b))).
+  
 Admitted.
 
 (* second part *)

--- a/theories/typing/contextual_refinement_alt.v
+++ b/theories/typing/contextual_refinement_alt.v
@@ -137,12 +137,22 @@ Proof.
   rewrite H.
 Admitted. 
 
+Lemma lim_exec_val_to_true e σ (b:bool) : lim_exec_val (e, σ) #b = lim_exec_val ((e = #b)%E, σ) #true.
+Proof.
+  replace ((e=#b)%E) with (fill_item (BinOpLCtx EqOp (#b)) e); last first.
+  { done. }
+  rewrite lim_exec_val_context_bind => /=.
+Admitted.
+
 Lemma lim_exec_val_mass_equal_true e σ: 
   SeriesC (lim_exec_val ((if: e then #() else loop)%E, σ)) = lim_exec_val (e,σ) (#true).
 Proof.
+  replace (if: e then #() else loop)%E with (fill_item (IfCtx #() loop) e); last first.
+  { done. }
+  rewrite lim_exec_val_context_bind => /=.
 Admitted.
 
-Lemma alt_impl_ctx_refines_loop_lemma e b σ:
+Lemma alt_impl_ctx_refines_loop_lemma e (b:bool) σ:
   lim_exec_val (e, σ) #b = SeriesC (lim_exec_val ((if: e = #b then #() else loop)%E, σ)).
 Proof.
   rewrite lim_exec_val_mass_equal_true.

--- a/theories/typing/contextual_refinement_alt.v
+++ b/theories/typing/contextual_refinement_alt.v
@@ -122,7 +122,30 @@ Proof.
     rewrite lim_exec_val_SeriesC_SeqV_true //.
 Qed.
 
+
+
 (*Other direction*)
+
+(* first part *)
+Lemma lim_exec_val_of_val_b_one e b σ: e = of_val #b -> lim_exec_val ((e = #b)%E, σ) #true = 1.
+Proof.
+  intros ->.
+  rewrite lim_exec_val_rw.
+Admitted.
+
+Lemma lim_exec_val_of_val_not_b_zero e b σ: e ≠ of_val #b -> lim_exec_val ((e = #b)%E, σ) #true = 0.
+Proof.
+  intros H.
+Admitted.
+
+Lemma lim_exec_val_is_b_test e σ (b:bool) : lim_exec_val (e, σ) #b = lim_exec_val ((e = #b)%E, σ) #true.
+Proof.
+  replace ((e=#b)%E) with (fill_item (BinOpLCtx EqOp (#b)) e); last first.
+  { done. }
+  rewrite lim_exec_val_context_bind => /=.
+Admitted.
+
+(* second part *)
 
 Definition loop := App (Rec "f" "x" (App (Var "f") (Var "x"))) (#()).
 
@@ -135,16 +158,17 @@ Proof.
   assert (H: (λ n, Rbar.Finite (exec_val n (loop, σ) x)) = λ n, 0).
   { admit. }
   rewrite H.
-Admitted. 
-
-Lemma lim_exec_val_to_true e σ (b:bool) : lim_exec_val (e, σ) #b = lim_exec_val ((e = #b)%E, σ) #true.
-Proof.
-  replace ((e=#b)%E) with (fill_item (BinOpLCtx EqOp (#b)) e); last first.
-  { done. }
-  rewrite lim_exec_val_context_bind => /=.
 Admitted.
 
-Lemma lim_exec_val_mass_equal_true e σ: 
+Lemma lim_exec_val_of_val_true_one e σ: e = #true -> lim_exec_val ((if: e then #() else loop)%E, σ) (#()) = 1.
+Proof.
+Admitted.
+
+Lemma lim_exec_val_of_val_not_true_zero e σ: e ≠ #true -> lim_exec_val ((if: e then #() else loop)%E, σ) (#()) = 0.
+Proof.
+  Admitted.
+
+Lemma lim_exec_val_is_true_test e σ: 
   SeriesC (lim_exec_val ((if: e then #() else loop)%E, σ)) = lim_exec_val (e,σ) (#true).
 Proof.
   replace (if: e then #() else loop)%E with (fill_item (IfCtx #() loop) e); last first.
@@ -152,11 +176,13 @@ Proof.
   rewrite lim_exec_val_context_bind => /=.
 Admitted.
 
+(*Combining both *)
 Lemma alt_impl_ctx_refines_loop_lemma e (b:bool) σ:
   lim_exec_val (e, σ) #b = SeriesC (lim_exec_val ((if: e = #b then #() else loop)%E, σ)).
 Proof.
-  rewrite lim_exec_val_mass_equal_true.
-Admitted.
+  rewrite lim_exec_val_is_true_test.
+  apply lim_exec_val_is_b_test.
+Qed. 
 
 Lemma alt_impl_ctx_refines Γ e1 e2 τ :
   ctx_refines_alt Γ e1 e2 τ -> (Γ ⊨ e1 ≤ctx≤ e2 : τ).


### PR DESCRIPTION
To prove the other direction that that the two definitions of contextual refinements coincide. 
See [Definition 1](https://github.com/logsem/clutch/blob/f2fb2bc89334355145a29be82d50873e9736d988/theories/typing/contextual_refinement.v#L229) and [Definition 2](https://github.com/logsem/clutch/blob/f2fb2bc89334355145a29be82d50873e9736d988/theories/typing/contextual_refinement_alt.v#L11)

Status: incomplete
------
Intermediate step completed: `lim_exec_val_context_bind`