### PR TITLE
Planner Rule 

### DIFF
--- a/theories/app_rel_logic/coupling_rules.v
+++ b/theories/app_rel_logic/coupling_rules.v
@@ -437,7 +437,7 @@ Section rules.
   Qed.
 
 
-  Lemma presample_planner N prefix suffix 𝛼 ε (HN : (0 < N)%nat) (HL : (0 < (length suffix))%nat) (Hε : (0 < ε)%R) :
+  Lemma presample_planner_pos N prefix suffix 𝛼 ε (HN : (0 < N)%nat) (HL : (0 < (length suffix))%nat) (Hε : (0 < ε)%R) :
     € ε -∗
     (𝛼 ↪ (N; prefix)) -∗
     (∃ junk, 𝛼 ↪ (N; prefix ++ junk ++ suffix)).
@@ -457,6 +457,19 @@ Section rules.
     rewrite /pos_to_nn /εAmp_iter /=.
     replace (nonneg ε) with (pos ε') by auto.
     done.
+  Qed.
+
+  Lemma presample_planner N prefix suffix 𝛼 ε (Hε : (0 < ε)%R) :
+    € ε -∗
+    (𝛼 ↪ (S N; prefix)) -∗
+    (∃ junk, 𝛼 ↪ (S N; prefix ++ junk ++ suffix)).
+  Proof.
+    destruct suffix as [|h R].
+    - iIntros "_ Htape". iExists []. do 2 (rewrite -app_nil_end); iFrame.
+    - remember (h :: R) as suffix.
+      iApply presample_planner_pos; auto; try lia.
+      rewrite Heqsuffix cons_length.
+      lia.
   Qed.
 
 End rules.

--- a/theories/app_rel_logic/seq_amplification.v
+++ b/theories/app_rel_logic/seq_amplification.v
@@ -1,0 +1,288 @@
+(** * Calculation for the Sequential Amplification Rile *)
+From stdpp Require Import namespaces.
+From iris.proofmode Require Import proofmode.
+From clutch.prelude Require Import stdpp_ext.
+From clutch.app_rel_logic Require Import lifting ectx_lifting.
+From clutch.prob_lang Require Import lang notation tactics metatheory.
+From clutch.app_rel_logic Require Export primitive_laws spec_rules.
+Require Import Lra.
+
+
+Section seq_ampl.
+  Local Open Scope R.
+  Implicit Types N l i : nat.
+  Implicit Types ε : nonnegreal.
+
+
+  Lemma pow_pos N : (0 < N)%nat -> forall w, (0 < w)%nat -> 0 < ((S N)^w - 1).
+  Proof.
+    intros w HN Hw.
+    apply (Rplus_lt_reg_r 1).
+    rewrite Rplus_assoc Rplus_opp_l Rplus_0_l Rplus_0_r.
+    apply Rlt_pow_R1; [apply lt_1_INR|]; lia.
+  Qed.
+
+  Lemma pow_nz N : (0 < N)%nat -> forall w, (w > 0)%nat -> ((S N)^w - 1) ≠ 0.
+  Proof.
+    intros.
+    apply Rgt_not_eq; apply Rlt_gt.
+    apply pow_pos; lia.
+  Qed.
+
+
+
+  (* well-formedness for k *)
+  (* well-formedness of k doesn't depend on the proof => OK to use proof irrelevence *)
+  Record kwf N l : Set := mk_kwf { N_lb : (0 < N)%nat; l_lb: (0 < l)%nat }.
+  Lemma kwf_ext N l (x : kwf N l) (y : kwf N l) : x = y.
+  Proof. destruct x; destruct y. Admitted.
+
+  (** amplification factor on our error *)
+  Definition k N l (kwf : kwf N l) : R := 1 + 1 / ((S N)^l - 1).
+
+
+  Lemma lt_1_k N l kwf : 1 < k N l kwf.
+  Proof.
+    destruct kwf as [Hn Hl].
+    remember {| N_lb := _; l_lb := _|} as kwf.
+    rewrite /k /Rdiv.
+    apply (Rmult_lt_reg_r ((S N)^l-1)); [by apply pow_pos|].
+    rewrite Rmult_plus_distr_r Rmult_assoc Rinv_l; [|by apply pow_nz].
+    lra.
+  Qed.
+
+  Lemma k_pos N l kwf : 0 < k N l kwf.
+  Proof. apply (Rlt_trans _ 1); [lra|apply lt_1_k; auto]. Qed.
+
+
+  (* well-formedness for fR *)
+  Record fRwf N l i : Set := mk_fRwf { k_wf : (kwf N l) ; i_ub : (i <= l)%nat }.
+  Lemma fRwf_dec_i N l i (fRbS : fRwf N l (S i)) : fRwf N l i.
+  Proof. destruct fRbS. apply mk_fRwf; auto; lia. Qed.
+  Lemma fRwf_upper N l : kwf N l -> fRwf N l l.
+  Proof. intros. apply mk_fRwf; auto. Qed.
+  Lemma fRwf_lower N l : kwf N l -> fRwf N l 0.
+  Proof. intros. apply mk_fRwf; auto. lia. Qed.
+  Lemma fRwf_ext N l i (x : fRwf N l i) (y : fRwf N l i) : x = y.
+  Proof. destruct x; destruct y. Admitted.
+
+
+  (** remainder factor on error after step i *)
+  Fixpoint fR N l i (fRwf : fRwf N l i) : R.
+    refine ((match i as m return (i = m) -> R with
+              0%nat    => fun _ => 1%nat
+            | (S i') => fun H => ((S N) * (fR N l i' _) - (k N l (fRwf.(k_wf N l i))) * N)
+            end) (eq_refl i)).
+    apply fRwf_dec_i; by rewrite -H.
+  Defined.
+
+  (* closed form 1: easy to do induction over i *)
+  Lemma fR_closed_1 N l i fRwf: (fR N l i fRwf) = (1 - (k N l (fRwf.(k_wf N l i)))) * (S N)^i + (k N l (fRwf.(k_wf N l i))).
+  Proof.
+    destruct fRwf as [[Hn Hl] Hi].
+    remember {| k_wf := _; i_ub := _|} as fRwf.
+
+    induction i as [|i' IH].
+    - simpl; lra.
+    - Opaque INR.
+      simpl fR. rewrite IH; [|lia|intros; apply fRwf_ext].
+      remember (k N l (k_wf N l i' (fRwf_dec_i N l i' fRwf))) as K.
+      replace (k N l (k_wf N l (S i') fRwf)) with K.
+      rewrite Rmult_plus_distr_l.
+      rewrite Rmult_comm Rmult_assoc (Rmult_comm  _ (S _)) tech_pow_Rmult.
+      rewrite /Rminus Rplus_assoc.
+      apply Rplus_eq_compat_l.
+      rewrite S_INR.
+      lra.
+  Qed.
+
+  (* closed forn 2: easy to bound *)
+  Lemma fR_closed_2 N l i fRwf: (fR N l i fRwf) = 1 - (((S N)^i - 1) / ((S N)^l - 1)).
+  Proof.
+    destruct fRwf as [[Hn Hl] Hi].
+    remember {| k_wf := _; i_ub := _|} as fRwf.
+    rewrite fR_closed_1.
+    rewrite /k /=. lra.
+  Qed.
+
+  (* much easier to prove this using closed form 2 *)
+  Lemma fR_nonneg N l i fRwf : 0 <= (fR N l i fRwf).
+  Proof.
+    destruct fRwf as [[Hn Hl] Hi].
+    remember {| k_wf := _; i_ub := _ |} as fRwf.
+    rewrite fR_closed_2.
+    rewrite /Rdiv.
+    apply (Rmult_le_reg_r (S N^l - 1)).
+    - rewrite /Rminus.
+      apply (Rplus_lt_reg_r 1).
+      rewrite Rplus_0_l Rplus_assoc Rplus_opp_l Rplus_0_r.
+      apply Rlt_pow_R1; [apply lt_1_INR|]; lia.
+    - rewrite Rmult_0_l.
+      rewrite Rmult_plus_distr_r /Rdiv Rmult_1_l.
+      rewrite Ropp_mult_distr_l_reverse.
+      rewrite Rmult_assoc Rinv_l; [|apply pow_nz; lia].
+      rewrite Rmult_1_r.
+      apply (Rplus_le_reg_r (S N^i - 1)).
+      rewrite Rplus_assoc Rplus_opp_l Rplus_0_l Rplus_0_r.
+      apply Rplus_le_compat_r.
+      apply Rle_pow; try lia.
+      apply Rlt_le.
+      apply lt_1_INR.
+      lia.
+  Qed.
+
+  (* fR will have the mean property we need *)
+  Lemma fR_mean N l i fRwf :
+    (S N) * (fR N l i (fRwf_dec_i N l i fRwf)) = N * (k N l (fRwf.(k_wf N l (S i)))) +  fR N l (S i) fRwf .
+  Proof. intros. rewrite /fR /=. lra. Qed.
+
+  (** Remaining error at each step *)
+  Program Definition εR N l i (ε : posreal) fRwf : nonnegreal
+    := mknonnegreal (ε * fR N l i fRwf) _.
+  Next Obligation.
+    intros.
+    apply Rmult_le_pos.
+      - apply Rlt_le. apply cond_pos.
+      - by apply fR_nonneg.
+  Qed.
+
+  Lemma εR_ext N l i (ε : posreal) fRwf1 fRwf2 : (εR N l i ε fRwf1 = εR N l i ε fRwf2).
+  Proof. f_equal. apply fRwf_ext. Qed.
+
+  Program Definition εAmp N l (ε : posreal) kwf : nonnegreal
+    := mknonnegreal (ε.(pos) * k N l kwf) _.
+  Next Obligation.
+    intros; simpl.
+    destruct ε; rewrite /RIneq.nonneg.
+    apply Rmult_le_pos.
+    - apply Rlt_le. auto.
+    - apply Rlt_le. apply k_pos.
+  Qed.
+
+  Program Definition εAmp_iter N l d (ε : posreal) kwf : posreal
+    := mkposreal (ε.(pos) * (k N l kwf)^d) _.
+  Next Obligation.
+    intros; simpl.
+    destruct ε; rewrite /RIneq.nonneg.
+    apply Rmult_lt_0_compat.
+    - auto.
+    - apply pow_lt. apply k_pos.
+  Qed.
+
+  Lemma εAmp_iter_cmp N l d (ε : posreal) kwf :
+    εAmp N l (εAmp_iter N l d ε kwf) kwf = pos_to_nn (εAmp_iter N l (S d) ε kwf).
+  Proof.
+    apply nnreal_ext.
+    rewrite /εAmp_iter /εAmp /pos_to_nn /=.
+    lra.
+  Qed.
+
+  Lemma εAmp_amplification N l (ε : posreal) kwf : ε < (εAmp N l ε kwf).
+  Proof.
+    rewrite /εAmp /=.
+    replace (pos ε) with (pos ε * 1) by apply Rmult_1_r.
+    rewrite Rmult_assoc.
+    apply Rmult_lt_compat_l.
+    - apply cond_pos.
+    - rewrite Rmult_1_l. apply lt_1_k; auto.
+  Qed.
+
+
+  (** Distribution for amplification at step i *)
+  Definition εDistr N l i (ε : posreal) target fRwf : (fin (S N)) -> nonnegreal
+    := fun sample => if (bool_decide (sample = target))
+                    then (εR N l (S i) ε fRwf)
+                    else (εAmp N l ε (fRwf.(k_wf N l (S i)))).
+
+
+  (** Mean lemma for calls to amplification *)
+  Lemma εDistr_mean N l i (ε : posreal) target fRwf :
+       SeriesC (λ n : fin (S N), (1 / INR (S N) * nonneg (εDistr N l i ε target fRwf n))%R)
+    = (εR N l i ε (fRwf_dec_i N l i fRwf)).
+  Proof.
+    destruct fRwf as [[Hn Hl] Hi].
+    remember {| k_wf := _; i_ub := _ |} as fRwf.
+
+    remember (fun n : fin _ => 1 / INR (S N) * nonneg (εDistr N l i ε target fRwf n))%R as body.
+    (* we want to exclude the n=target case, and then it's a constant *)
+
+    assert (body_pos : ∀ a : fin _, 0 <= body a).
+    { intro a.
+      rewrite Heqbody.
+      apply Rmult_le_pos.
+      - apply Rle_mult_inv_pos; [lra|apply lt_0_INR; lia].
+      - destruct εDistr. simpl; lra. }
+    rewrite (SeriesC_split_elem body target body_pos); try (apply ex_seriesC_finite).
+    simpl.
+
+    (* FIXME: Revisit that thing about rewriting under the function
+        setoid something?
+        Then we don't need the dependent versions of the function in this case
+
+     *)
+
+    (* this will come up a bunch *)
+    assert (HSN : not (@eq R (INR (S N)) (IZR Z0))).
+    { rewrite S_INR. apply Rgt_not_eq. apply Rcomplements.INRp1_pos. }
+
+
+    (* Evaluate the first series *)
+    replace (SeriesC (λ a : fin _, if bool_decide (a = target) then body a else 0))
+       with (1 / INR (S N) * (εR N l (S i) ε fRwf)); last first.
+    { rewrite SeriesC_singleton_dependent.
+      rewrite Heqbody /εDistr.
+      rewrite bool_decide_true; try auto. }
+
+    (* Evaluate the second series *)
+    replace (SeriesC (λ a : fin _, if bool_decide (not (a = target)) then body a else 0))
+       with (N  * / INR (S N) * (εAmp N l ε (fRwf.(k_wf N l (S i))))); last first.
+    { apply (Rplus_eq_reg_l (1 * / INR (S N) * (εAmp N l ε (fRwf.(k_wf N l (S i)))))).
+      (* simplify the LHS *)
+      do 2 rewrite Rmult_assoc.
+      rewrite -Rmult_plus_distr_r.
+      rewrite Rplus_comm -S_INR -Rmult_assoc Rinv_r; try auto.
+      do 2 rewrite Rmult_1_l.
+
+
+      (* turn the first term on the RHS into a singleton series, and combine into constant series *)
+      rewrite -(SeriesC_singleton target  (/ INR (S N) * _)).
+      rewrite -SeriesC_plus; try (apply ex_seriesC_finite).
+      rewrite -(SeriesC_ext (fun x : fin (S N) => / INR (S N) * (εAmp N l ε (fRwf.(k_wf N l (S i)))))); last first.
+      { (* series are extensionally equal*)
+        intros n.
+        case_bool_decide.
+        - rewrite bool_decide_false; auto. lra.
+        - rewrite bool_decide_true; auto.
+          rewrite Heqbody /εDistr.
+          rewrite bool_decide_false; auto.
+          rewrite Rplus_0_l /Rdiv Rmult_1_l.
+          apply Rmult_eq_compat_l.
+          by simpl nonneg. }
+
+      (* compute the finite series *)
+      rewrite SeriesC_finite_mass fin_card.
+      rewrite -Rmult_assoc Rinv_r; try auto.
+      lra.
+    }
+
+    (* Multiply everything by S N*)
+    apply (Rmult_eq_reg_l (INR (S N))); [| apply not_0_INR;lia].
+    rewrite Rmult_plus_distr_l -Rmult_assoc /Rdiv.
+    rewrite Rmult_1_l Rinv_r; [| apply not_0_INR;lia].
+    rewrite Rmult_1_l.
+    rewrite -Rmult_assoc (Rmult_comm _ ( / INR (S N))) -Rmult_assoc.
+    rewrite Rinv_r; [| apply not_0_INR;lia].
+    rewrite Rmult_1_l.
+
+    (* Turn everything into fR and k by dividing out 𝜀*)
+    rewrite /εR. Opaque fR. simpl nonneg.
+    do 2 rewrite (Rmult_comm (INR _)) Rmult_assoc.
+    rewrite -Rmult_plus_distr_l.
+    apply Rmult_eq_compat_l.
+
+    (* apply fR_mean and conclude *)
+    rewrite (Rmult_comm _ (INR (S N))).
+    rewrite (fR_mean N); try lia.
+    lra.
+  Qed.
+End seq_ampl.

--- a/theories/prob/countable_sum.v
+++ b/theories/prob/countable_sum.v
@@ -341,13 +341,35 @@ Section filter.
       exfalso. apply Hneq. symmetry. by apply encode_inv_Some_nat.
   Qed.
 
+  (* same proof as is_seriesC_singleton but stronger *)
+  Lemma is_seriesC_singleton_dependent (a : A) v :
+    is_seriesC (λ (n : A), if bool_decide (n = a) then v n else 0) (v a).
+  Proof.
+    rewrite /is_seriesC.
+    eapply is_series_ext; [|apply (is_series_singleton (encode_nat a))].
+    intros n =>/=. rewrite /countable_sum.
+    case_bool_decide as Hneq=>/=; subst.
+    - rewrite encode_inv_encode_nat //= bool_decide_eq_true_2 //.
+    - destruct (encode_inv_nat _) eqn:Heq=>//=.
+      case_bool_decide; [|done]; subst.
+      exfalso. apply Hneq. symmetry. by apply encode_inv_Some_nat.
+  Qed.
+
   Lemma ex_seriesC_singleton (a : A) v :
     ex_seriesC (λ (n : A), if bool_decide (n = a) then v else 0).
   Proof. eexists. eapply is_seriesC_singleton. Qed.
 
+  Lemma ex_seriesC_singleton_dependent (a : A) v :
+    ex_seriesC (λ (n : A), if bool_decide (n = a) then v n else 0).
+  Proof. eexists. eapply is_seriesC_singleton_dependent. Qed.
+
   Lemma SeriesC_singleton (a : A) v :
     SeriesC (λ n, if bool_decide (n = a) then v else 0) = v.
   Proof. apply is_series_unique, is_seriesC_singleton. Qed.
+
+  Lemma SeriesC_singleton_dependent (a : A) v :
+    SeriesC (λ n, if bool_decide (n = a) then v n else 0) = v a.
+  Proof. apply is_series_unique, is_seriesC_singleton_dependent. Qed.
 
   Lemma is_seriesC_singleton_inj (b : B) (f : A -> B) v `{Inj A B (=) (=) f} :
     (∃ a, f a = b) →
@@ -400,6 +422,7 @@ Section filter.
     + intro a'; rewrite (bool_decide_ext (a = a') (a' = a)); done.
     + apply ex_seriesC_singleton.
   Qed.
+
 
   Lemma SeriesC_singleton' (a : A) v :
     SeriesC (λ n, if bool_decide (a = n) then v else 0) = v.


### PR DESCRIPTION
Proof of the planner rule from the [Arons Pnueli Zuck paper](https://link.springer.com/chapter/10.1007/3-540-36576-1_6). The main result is 
```
Lemma presample_planner N prefix suffix 𝛼 ε (Hε : (0 < ε)%R) :
  € ε -∗ (𝛼 ↪ (S N; prefix)) -∗ (∃ junk, 𝛼 ↪ (S N; prefix ++ junk ++ suffix)).                                                                                    
```
which says that we can use any amount of credit to eventually presample any sequence on a tape. 


The main admitted lemmas are:
- [ ] A rule for spending 1 credit
```
Lemma ec_spend_1 ε1 : (1 <= ε1.(nonneg))%R → € ε1 -∗ False.
```
- [ ] An advanced composition rule:
```
Lemma presample_adv_comp (N : nat) α ns (ε : nonnegreal) (ε2 : fin (S N) -∗ nonnegreal)) : 
  SeriesC (λ n, (1 / (S N)) * ε2 n)%R = (nonneg ε) →           
  (α ↪ (N; ns) ∗ € ε) -∗ (∃ s, (α ↪ (N; ns ++ [s])) ∗ €(ε2 s)).
``` 

It is written in the relational logic only because the UB logic does not have tapes. Assuming we want this proof rule we should decide if we're going to embed the UB logic in the relational logic-- if not we should add presampling tapes to the UB logic. 