### PR TITLE
Support for presampling tapes in the UB logic 

### DIFF
--- a/theories/prob/countable_sum.v
+++ b/theories/prob/countable_sum.v
@@ -378,20 +378,6 @@ Section filter.
 
   Implicit Types P Q : A → Prop.
 
-  Lemma is_seriesC_singleton (a : A) v :
-    is_seriesC (λ (n : A), if bool_decide (n = a) then v else 0) v.
-  Proof.
-    rewrite /is_seriesC.
-    eapply is_series_ext; [|apply (is_series_singleton (encode_nat a))].
-    intros n =>/=. rewrite /countable_sum.
-    case_bool_decide as Hneq=>/=; subst.
-    - rewrite encode_inv_encode_nat //= bool_decide_eq_true_2 //.
-    - destruct (encode_inv_nat _) eqn:Heq=>//=.
-      case_bool_decide; [|done]; subst.
-      exfalso. apply Hneq. symmetry. by apply encode_inv_Some_nat.
-  Qed.
-
-  (* same proof as is_seriesC_singleton but stronger *)
   Lemma is_seriesC_singleton_dependent (a : A) v :
     is_seriesC (λ (n : A), if bool_decide (n = a) then v n else 0) (v a).
   Proof.
@@ -405,21 +391,25 @@ Section filter.
       exfalso. apply Hneq. symmetry. by apply encode_inv_Some_nat.
   Qed.
 
-  Lemma ex_seriesC_singleton (a : A) v :
-    ex_seriesC (λ (n : A), if bool_decide (n = a) then v else 0).
-  Proof. eexists. eapply is_seriesC_singleton. Qed.
+  Lemma is_seriesC_singleton (a : A) v :
+    is_seriesC (λ (n : A), if bool_decide (n = a) then v else 0) v.
+  Proof. apply is_seriesC_singleton_dependent. Qed.
 
   Lemma ex_seriesC_singleton_dependent (a : A) v :
     ex_seriesC (λ (n : A), if bool_decide (n = a) then v n else 0).
   Proof. eexists. eapply is_seriesC_singleton_dependent. Qed.
 
-  Lemma SeriesC_singleton (a : A) v :
-    SeriesC (λ n, if bool_decide (n = a) then v else 0) = v.
-  Proof. apply is_series_unique, is_seriesC_singleton. Qed.
+  Lemma ex_seriesC_singleton (a : A) v :
+    ex_seriesC (λ (n : A), if bool_decide (n = a) then v else 0).
+  Proof. eexists. eapply is_seriesC_singleton. Qed.
 
   Lemma SeriesC_singleton_dependent (a : A) v :
     SeriesC (λ n, if bool_decide (n = a) then v n else 0) = v a.
   Proof. apply is_series_unique, is_seriesC_singleton_dependent. Qed.
+
+  Lemma SeriesC_singleton (a : A) v :
+    SeriesC (λ n, if bool_decide (n = a) then v else 0) = v.
+  Proof. apply is_series_unique, is_seriesC_singleton. Qed.
 
   Lemma is_seriesC_singleton_inj (b : B) (f : A → B) v `{Inj A B (=) (=) f} :
     (∃ a, f a = b) →

--- a/theories/prob/countable_sum.v
+++ b/theories/prob/countable_sum.v
@@ -391,13 +391,35 @@ Section filter.
       exfalso. apply Hneq. symmetry. by apply encode_inv_Some_nat.
   Qed.
 
+  (* same proof as is_seriesC_singleton but stronger *)
+  Lemma is_seriesC_singleton_dependent (a : A) v :
+    is_seriesC (λ (n : A), if bool_decide (n = a) then v n else 0) (v a).
+  Proof.
+    rewrite /is_seriesC.
+    eapply is_series_ext; [|apply (is_series_singleton (encode_nat a))].
+    intros n =>/=. rewrite /countable_sum.
+    case_bool_decide as Hneq=>/=; subst.
+    - rewrite encode_inv_encode_nat //= bool_decide_eq_true_2 //.
+    - destruct (encode_inv_nat _) eqn:Heq=>//=.
+      case_bool_decide; [|done]; subst.
+      exfalso. apply Hneq. symmetry. by apply encode_inv_Some_nat.
+  Qed.
+
   Lemma ex_seriesC_singleton (a : A) v :
     ex_seriesC (λ (n : A), if bool_decide (n = a) then v else 0).
   Proof. eexists. eapply is_seriesC_singleton. Qed.
 
+  Lemma ex_seriesC_singleton_dependent (a : A) v :
+    ex_seriesC (λ (n : A), if bool_decide (n = a) then v n else 0).
+  Proof. eexists. eapply is_seriesC_singleton_dependent. Qed.
+
   Lemma SeriesC_singleton (a : A) v :
     SeriesC (λ n, if bool_decide (n = a) then v else 0) = v.
   Proof. apply is_series_unique, is_seriesC_singleton. Qed.
+
+  Lemma SeriesC_singleton_dependent (a : A) v :
+    SeriesC (λ n, if bool_decide (n = a) then v n else 0) = v a.
+  Proof. apply is_series_unique, is_seriesC_singleton_dependent. Qed.
 
   Lemma is_seriesC_singleton_inj (b : B) (f : A → B) v `{Inj A B (=) (=) f} :
     (∃ a, f a = b) →

--- a/theories/ub_logic/adequacy.v
+++ b/theories/ub_logic/adequacy.v
@@ -106,13 +106,39 @@ Section adequacy.
           erewrite (Rcoupl_eq_elim _ _ (prim_coupl_step_prim _ _ _ _ _ Hα)); eauto.
           eapply ub_lift_dbind; eauto; [apply cond_nonneg | ].
           apply cond_nonneg.
+        - iIntros (??).
+          by iMod ("H" with "[//] [//]") as "W". }
+      iInduction (language.get_active σ1) as [| α] "IH"; [done|].
+      rewrite big_orL_cons.
+      iDestruct "H" as "[H | Ht]"; [done|].
+      by iApply "IH".
+   - rewrite exec_Sn_not_final; [|eauto].
+      iDestruct (big_orL_mono _ (λ _ _,
+                     |={∅}▷=>^(S n)
+                       ⌜ub_lift (prim_step e1 σ1 ≫= exec n) φ ε''⌝)%I
+                  with "H") as "H".
+      { iIntros (i α Hα%elem_of_list_lookup_2) "(% & %ε1 & %ε2 & %Hε'' & %Hleq & %Hlift & H)".
+        replace (prim_step e1 σ1) with (step (e1, σ1)) => //.
+        rewrite -exec_Sn_not_final; [|eauto].
+        iApply (step_fupdN_mono _ _ _
+                  (⌜∀ σ2 , R2 σ2 → ub_lift (exec (S n) (e1, σ2)) φ (ε2 (e1, σ2))⌝)%I).
+        - iIntros (?). iPureIntro.
+          rewrite /= /get_active in Hα.
+          apply elem_of_elements, elem_of_dom in Hα as [bs Hα].
+
+          erewrite (Rcoupl_eq_elim _ _ (prim_coupl_step_prim _ _ _ _ _ Hα)); eauto.
+          apply (UB_mon_grading _ _
+                   (ε1 + (SeriesC (λ ρ : language.state prob_lang, language.state_step σ1 α ρ * ε2 (e1, ρ))))) => //.
+          eapply ub_lift_dbind_adv; eauto; [by destruct ε1|].
+          destruct Hε'' as [r Hr]; exists r.
+          intros a.
+          split; [by destruct (ε2 _) | by apply Hr].
         - iIntros (??). by iMod ("H" with "[//] [//]"). }
       iInduction (language.get_active σ1) as [| α] "IH"; [done|].
       rewrite big_orL_cons.
       iDestruct "H" as "[H | Ht]"; [done|].
       by iApply "IH".
-   - admit.
-  Admitted.
+  Qed.
 
   Theorem wp_refRcoupl_step_fupdN (e : expr) (σ : state) (ε : nonnegreal) n φ  :
     state_interp σ ∗ err_interp (ε) ∗ WP e {{ v, ⌜φ v⌝ }} ⊢

--- a/theories/ub_logic/adequacy.v
+++ b/theories/ub_logic/adequacy.v
@@ -69,7 +69,7 @@ Section adequacy.
     }
     clear.
     iIntros "!#" ([ε'' [e1 σ1]]). rewrite /Φ/F/exec_ub_pre.
-    iIntros "[ (%R & %ε1 & %ε2 & % & %Hlift & H)| [ (%R & %ε1 & %ε2 & (%r & %Hr) & % & %Hlift & H)| H]] %Hv".
+    iIntros "[ (%R & %ε1 & %ε2 & % & %Hlift & H)| [ (%R & %ε1 & %ε2 & (%r & %Hr) & % & %Hlift & H)| [H|H]]] %Hv".
     - iApply step_fupdN_mono.
       { apply pure_mono.
         eapply UB_mon_grading; eauto. }
@@ -111,7 +111,8 @@ Section adequacy.
       rewrite big_orL_cons.
       iDestruct "H" as "[H | Ht]"; [done|].
       by iApply "IH".
-  Qed.
+   - admit.
+  Admitted.
 
   Theorem wp_refRcoupl_step_fupdN (e : expr) (σ : state) (ε : nonnegreal) n φ  :
     state_interp σ ∗ err_interp (ε) ∗ WP e {{ v, ⌜φ v⌝ }} ⊢

--- a/theories/ub_logic/adequacy.v
+++ b/theories/ub_logic/adequacy.v
@@ -124,7 +124,6 @@ Section adequacy.
         - iIntros (?). iPureIntro.
           rewrite /= /get_active in Hα.
           apply elem_of_elements, elem_of_dom in Hα as [bs Hα].
-
           erewrite (Rcoupl_eq_elim _ _ (prim_coupl_step_prim _ _ _ _ _ Hα)); eauto.
           apply (UB_mon_grading _ _
                    (ε1 + (SeriesC (λ ρ : language.state prob_lang, language.state_step σ1 α ρ * ε2 (e1, ρ))))) => //.

--- a/theories/ub_logic/adequacy.v
+++ b/theories/ub_logic/adequacy.v
@@ -69,7 +69,7 @@ Section adequacy.
     }
     clear.
     iIntros "!#" ([ε'' [e1 σ1]]). rewrite /Φ/F/exec_ub_pre.
-    iIntros "[ (%R & %ε1 & %ε2 & % & %Hlift & H)| [ (%R & %ε1 & %ε2 & (%r & %Hr) & % & %Hlift & H)| [H|H]]] %Hv".
+    iIntros "[ (%R & %ε1 & %ε2 & %Hred & % & %Hlift & H)| [ (%R & %ε1 & %ε2 & %Hred & (%r & %Hr) & % & %Hlift & H)| [H|H]]] %Hv".
     - iApply step_fupdN_mono.
       { apply pure_mono.
         eapply UB_mon_grading; eauto. }
@@ -94,7 +94,7 @@ Section adequacy.
                      |={∅}▷=>^(S n)
                        ⌜ub_lift (prim_step e1 σ1 ≫= exec n) φ ε''⌝)%I
                   with "H") as "H".
-      { iIntros (i α Hα%elem_of_list_lookup_2) "(% & %ε1 & %ε2 & %Hleq & %Hlift & H)".
+      { iIntros (i α Hα%elem_of_list_lookup_2) "(% & %ε1 & %ε2 & %Hleq & %Hlift & %Hred & H)".
         replace (prim_step e1 σ1) with (step (e1, σ1)) => //.
         rewrite -exec_Sn_not_final; [|eauto].
         iApply (step_fupdN_mono _ _ _
@@ -170,7 +170,7 @@ Section adequacy.
         apply (UB_mon_grading _ _ 0); [apply cond_nonneg | ].
         apply ub_lift_dret; auto.
       + rewrite ub_wp_unfold /ub_wp_pre /= Heq.
-        iMod ("Hwp" with "[$]") as "(%Hexec_ub & Hlift)".
+        iMod ("Hwp" with "[$]") as "Hlift".
         iModIntro.
         iPoseProof
           (exec_ub_mono _ (λ ε' '(e2, σ2), |={∅}▷=>^(S n)

--- a/theories/ub_logic/adequacy.v
+++ b/theories/ub_logic/adequacy.v
@@ -106,8 +106,7 @@ Section adequacy.
           erewrite (Rcoupl_eq_elim _ _ (prim_coupl_step_prim _ _ _ _ _ Hα)); eauto.
           eapply ub_lift_dbind; eauto; [apply cond_nonneg | ].
           apply cond_nonneg.
-        - iIntros (??).
-          by iMod ("H" with "[//] [//]") as "W". }
+        - iIntros (??). by iMod ("H" with "[//] [//]"). }
       iInduction (language.get_active σ1) as [| α] "IH"; [done|].
       rewrite big_orL_cons.
       iDestruct "H" as "[H | Ht]"; [done|].

--- a/theories/ub_logic/adequacy.v
+++ b/theories/ub_logic/adequacy.v
@@ -94,7 +94,7 @@ Section adequacy.
                      |={∅}▷=>^(S n)
                        ⌜ub_lift (prim_step e1 σ1 ≫= exec n) φ ε''⌝)%I
                   with "H") as "H".
-      { iIntros (i α Hα%elem_of_list_lookup_2) "(% & %ε1 & %ε2 & %Hleq & %Hlift & %Hred & H)".
+      { iIntros (i α Hα%elem_of_list_lookup_2) "(% & %ε1 & %ε2 & %Hleq & %Hlift & H)".
         replace (prim_step e1 σ1) with (step (e1, σ1)) => //.
         rewrite -exec_Sn_not_final; [|eauto].
         iApply (step_fupdN_mono _ _ _

--- a/theories/ub_logic/lifting.v
+++ b/theories/ub_logic/lifting.v
@@ -21,7 +21,6 @@ Lemma wp_lift_step_fupd_exec_ub E Φ e1 :
   (∀ σ1 ε,
     state_interp σ1 ∗ err_interp ε
     ={E,∅}=∗
-    ⌜reducible e1 σ1⌝ ∗
     exec_ub e1 σ1 (λ ε2 '(e2, σ2),
       ▷ |={∅,E}=> state_interp σ2 ∗ err_interp ε2 ∗ WP e2 @ E {{ Φ }}) ε)
   ⊢ WP e1 @ E {{ Φ }}.
@@ -45,11 +44,12 @@ Proof.
   iApply wp_lift_step_fupd_exec_ub; [done|].
   iIntros (σ1 ε) "[Hσ Hε]".
   iMod ("H" with "Hσ") as "[%Hs H]". iModIntro.
-  iSplit; [done|].
   iApply (exec_ub_prim_step e1 σ1).
   iExists _.
   iExists nnreal_zero.
   iExists ε.
+  iSplit.
+  { iPureIntro. simpl. done. }
   iSplit.
   { iPureIntro. simpl. lra. }
   iSplit.

--- a/theories/ub_logic/seq_amplification.v
+++ b/theories/ub_logic/seq_amplification.v
@@ -1,0 +1,287 @@
+(** * Calculation for the Sequential Amplification Rile *)
+From stdpp Require Import namespaces.
+From iris.proofmode Require Import proofmode.
+From clutch.prelude Require Import stdpp_ext NNRbar.
+From clutch.app_rel_logic Require Import lifting ectx_lifting.
+From clutch.prob_lang Require Import lang notation tactics metatheory.
+Require Import Lra.
+
+
+Section seq_ampl.
+  Local Open Scope R.
+  Implicit Types N l i : nat.
+  Implicit Types ε : nonnegreal.
+
+
+  Lemma pow_pos N : (0 < N)%nat -> forall w, (0 < w)%nat -> 0 < ((S N)^w - 1).
+  Proof.
+    intros w HN Hw.
+    apply (Rplus_lt_reg_r 1).
+    rewrite Rplus_assoc Rplus_opp_l Rplus_0_l Rplus_0_r.
+    apply Rlt_pow_R1; [apply lt_1_INR|]; lia.
+  Qed.
+
+  Lemma pow_nz N : (0 < N)%nat -> forall w, (w > 0)%nat -> ((S N)^w - 1) ≠ 0.
+  Proof.
+    intros.
+    apply Rgt_not_eq; apply Rlt_gt.
+    apply pow_pos; lia.
+  Qed.
+
+
+
+  (* well-formedness for k *)
+  (* well-formedness of k doesn't depend on the proof => OK to use proof irrelevence *)
+  Record kwf N l : Set := mk_kwf { N_lb : (0 < N)%nat; l_lb: (0 < l)%nat }.
+  Lemma kwf_ext N l (x : kwf N l) (y : kwf N l) : x = y.
+  Proof. destruct x; destruct y. Admitted.
+
+  (** amplification factor on our error *)
+  Definition k N l (kwf : kwf N l) : R := 1 + 1 / ((S N)^l - 1).
+
+
+  Lemma lt_1_k N l kwf : 1 < k N l kwf.
+  Proof.
+    destruct kwf as [Hn Hl].
+    remember {| N_lb := _; l_lb := _|} as kwf.
+    rewrite /k /Rdiv.
+    apply (Rmult_lt_reg_r ((S N)^l-1)); [by apply pow_pos|].
+    rewrite Rmult_plus_distr_r Rmult_assoc Rinv_l; [|by apply pow_nz].
+    lra.
+  Qed.
+
+  Lemma k_pos N l kwf : 0 < k N l kwf.
+  Proof. apply (Rlt_trans _ 1); [lra|apply lt_1_k; auto]. Qed.
+
+
+  (* well-formedness for fR *)
+  Record fRwf N l i : Set := mk_fRwf { k_wf : (kwf N l) ; i_ub : (i <= l)%nat }.
+  Lemma fRwf_dec_i N l i (fRbS : fRwf N l (S i)) : fRwf N l i.
+  Proof. destruct fRbS. apply mk_fRwf; auto; lia. Qed.
+  Lemma fRwf_upper N l : kwf N l -> fRwf N l l.
+  Proof. intros. apply mk_fRwf; auto. Qed.
+  Lemma fRwf_lower N l : kwf N l -> fRwf N l 0.
+  Proof. intros. apply mk_fRwf; auto. lia. Qed.
+  Lemma fRwf_ext N l i (x : fRwf N l i) (y : fRwf N l i) : x = y.
+  Proof. destruct x; destruct y. Admitted.
+
+
+  (** remainder factor on error after step i *)
+  Fixpoint fR N l i (fRwf : fRwf N l i) : R.
+    refine ((match i as m return (i = m) -> R with
+              0%nat    => fun _ => 1%nat
+            | (S i') => fun H => ((S N) * (fR N l i' _) - (k N l (fRwf.(k_wf N l i))) * N)
+            end) (eq_refl i)).
+    apply fRwf_dec_i; by rewrite -H.
+  Defined.
+
+  (* closed form 1: easy to do induction over i *)
+  Lemma fR_closed_1 N l i fRwf: (fR N l i fRwf) = (1 - (k N l (fRwf.(k_wf N l i)))) * (S N)^i + (k N l (fRwf.(k_wf N l i))).
+  Proof.
+    destruct fRwf as [[Hn Hl] Hi].
+    remember {| k_wf := _; i_ub := _|} as fRwf.
+
+    induction i as [|i' IH].
+    - simpl; lra.
+    - Opaque INR.
+      simpl fR. rewrite IH; [|lia|intros; apply fRwf_ext].
+      remember (k N l (k_wf N l i' (fRwf_dec_i N l i' fRwf))) as K.
+      replace (k N l (k_wf N l (S i') fRwf)) with K.
+      rewrite Rmult_plus_distr_l.
+      rewrite Rmult_comm Rmult_assoc (Rmult_comm  _ (S _)) tech_pow_Rmult.
+      rewrite /Rminus Rplus_assoc.
+      apply Rplus_eq_compat_l.
+      rewrite S_INR.
+      lra.
+  Qed.
+
+  (* closed forn 2: easy to bound *)
+  Lemma fR_closed_2 N l i fRwf: (fR N l i fRwf) = 1 - (((S N)^i - 1) / ((S N)^l - 1)).
+  Proof.
+    destruct fRwf as [[Hn Hl] Hi].
+    remember {| k_wf := _; i_ub := _|} as fRwf.
+    rewrite fR_closed_1.
+    rewrite /k /=. lra.
+  Qed.
+
+  (* much easier to prove this using closed form 2 *)
+  Lemma fR_nonneg N l i fRwf : 0 <= (fR N l i fRwf).
+  Proof.
+    destruct fRwf as [[Hn Hl] Hi].
+    remember {| k_wf := _; i_ub := _ |} as fRwf.
+    rewrite fR_closed_2.
+    rewrite /Rdiv.
+    apply (Rmult_le_reg_r (S N^l - 1)).
+    - rewrite /Rminus.
+      apply (Rplus_lt_reg_r 1).
+      rewrite Rplus_0_l Rplus_assoc Rplus_opp_l Rplus_0_r.
+      apply Rlt_pow_R1; [apply lt_1_INR|]; lia.
+    - rewrite Rmult_0_l.
+      rewrite Rmult_plus_distr_r /Rdiv Rmult_1_l.
+      rewrite Ropp_mult_distr_l_reverse.
+      rewrite Rmult_assoc Rinv_l; [|apply pow_nz; lia].
+      rewrite Rmult_1_r.
+      apply (Rplus_le_reg_r (S N^i - 1)).
+      rewrite Rplus_assoc Rplus_opp_l Rplus_0_l Rplus_0_r.
+      apply Rplus_le_compat_r.
+      apply Rle_pow; try lia.
+      apply Rlt_le.
+      apply lt_1_INR.
+      lia.
+  Qed.
+
+  (* fR will have the mean property we need *)
+  Lemma fR_mean N l i fRwf :
+    (S N) * (fR N l i (fRwf_dec_i N l i fRwf)) = N * (k N l (fRwf.(k_wf N l (S i)))) +  fR N l (S i) fRwf .
+  Proof. intros. rewrite /fR /=. lra. Qed.
+
+  (** Remaining error at each step *)
+  Program Definition εR N l i (ε : posreal) fRwf : nonnegreal
+    := mknonnegreal (ε * fR N l i fRwf) _.
+  Next Obligation.
+    intros.
+    apply Rmult_le_pos.
+      - apply Rlt_le. apply cond_pos.
+      - by apply fR_nonneg.
+  Qed.
+
+  Lemma εR_ext N l i (ε : posreal) fRwf1 fRwf2 : (εR N l i ε fRwf1 = εR N l i ε fRwf2).
+  Proof. f_equal. apply fRwf_ext. Qed.
+
+  Program Definition εAmp N l (ε : posreal) kwf : nonnegreal
+    := mknonnegreal (ε.(pos) * k N l kwf) _.
+  Next Obligation.
+    intros; simpl.
+    destruct ε; rewrite /RIneq.nonneg.
+    apply Rmult_le_pos.
+    - apply Rlt_le. auto.
+    - apply Rlt_le. apply k_pos.
+  Qed.
+
+  Program Definition εAmp_iter N l d (ε : posreal) kwf : posreal
+    := mkposreal (ε.(pos) * (k N l kwf)^d) _.
+  Next Obligation.
+    intros; simpl.
+    destruct ε; rewrite /RIneq.nonneg.
+    apply Rmult_lt_0_compat.
+    - auto.
+    - apply pow_lt. apply k_pos.
+  Qed.
+
+  Lemma εAmp_iter_cmp N l d (ε : posreal) kwf :
+    εAmp N l (εAmp_iter N l d ε kwf) kwf = pos_to_nn (εAmp_iter N l (S d) ε kwf).
+  Proof.
+    apply nnreal_ext.
+    rewrite /εAmp_iter /εAmp /pos_to_nn /=.
+    lra.
+  Qed.
+
+  Lemma εAmp_amplification N l (ε : posreal) kwf : ε < (εAmp N l ε kwf).
+  Proof.
+    rewrite /εAmp /=.
+    replace (pos ε) with (pos ε * 1) by apply Rmult_1_r.
+    rewrite Rmult_assoc.
+    apply Rmult_lt_compat_l.
+    - apply cond_pos.
+    - rewrite Rmult_1_l. apply lt_1_k; auto.
+  Qed.
+
+
+  (** Distribution for amplification at step i *)
+  Definition εDistr N l i (ε : posreal) target fRwf : (fin (S N)) -> nonnegreal
+    := fun sample => if (bool_decide (sample = target))
+                    then (εR N l (S i) ε fRwf)
+                    else (εAmp N l ε (fRwf.(k_wf N l (S i)))).
+
+
+  (** Mean lemma for calls to amplification *)
+  Lemma εDistr_mean N l i (ε : posreal) target fRwf :
+       SeriesC (λ n : fin (S N), (1 / INR (S N) * nonneg (εDistr N l i ε target fRwf n))%R)
+    = (εR N l i ε (fRwf_dec_i N l i fRwf)).
+  Proof.
+    destruct fRwf as [[Hn Hl] Hi].
+    remember {| k_wf := _; i_ub := _ |} as fRwf.
+
+    remember (fun n : fin _ => 1 / INR (S N) * nonneg (εDistr N l i ε target fRwf n))%R as body.
+    (* we want to exclude the n=target case, and then it's a constant *)
+
+    assert (body_pos : ∀ a : fin _, 0 <= body a).
+    { intro a.
+      rewrite Heqbody.
+      apply Rmult_le_pos.
+      - apply Rle_mult_inv_pos; [lra|apply lt_0_INR; lia].
+      - destruct εDistr. simpl; lra. }
+    rewrite (SeriesC_split_elem body target body_pos); try (apply ex_seriesC_finite).
+    simpl.
+
+    (* FIXME: Revisit that thing about rewriting under the function
+        setoid something?
+        Then we don't need the dependent versions of the function in this case
+
+     *)
+
+    (* this will come up a bunch *)
+    assert (HSN : not (@eq R (INR (S N)) (IZR Z0))).
+    { rewrite S_INR. apply Rgt_not_eq. apply Rcomplements.INRp1_pos. }
+
+
+    (* Evaluate the first series *)
+    replace (SeriesC (λ a : fin _, if bool_decide (a = target) then body a else 0))
+       with (1 / INR (S N) * (εR N l (S i) ε fRwf)); last first.
+    { rewrite SeriesC_singleton_dependent.
+      rewrite Heqbody /εDistr.
+      rewrite bool_decide_true; try auto. }
+
+    (* Evaluate the second series *)
+    replace (SeriesC (λ a : fin _, if bool_decide (not (a = target)) then body a else 0))
+       with (N  * / INR (S N) * (εAmp N l ε (fRwf.(k_wf N l (S i))))); last first.
+    { apply (Rplus_eq_reg_l (1 * / INR (S N) * (εAmp N l ε (fRwf.(k_wf N l (S i)))))).
+      (* simplify the LHS *)
+      do 2 rewrite Rmult_assoc.
+      rewrite -Rmult_plus_distr_r.
+      rewrite Rplus_comm -S_INR -Rmult_assoc Rinv_r; try auto.
+      do 2 rewrite Rmult_1_l.
+
+
+      (* turn the first term on the RHS into a singleton series, and combine into constant series *)
+      rewrite -(SeriesC_singleton target  (/ INR (S N) * _)).
+      rewrite -SeriesC_plus; try (apply ex_seriesC_finite).
+      rewrite -(SeriesC_ext (fun x : fin (S N) => / INR (S N) * (εAmp N l ε (fRwf.(k_wf N l (S i)))))); last first.
+      { (* series are extensionally equal*)
+        intros n.
+        case_bool_decide.
+        - rewrite bool_decide_false; auto. lra.
+        - rewrite bool_decide_true; auto.
+          rewrite Heqbody /εDistr.
+          rewrite bool_decide_false; auto.
+          rewrite Rplus_0_l /Rdiv Rmult_1_l.
+          apply Rmult_eq_compat_l.
+          by simpl nonneg. }
+
+      (* compute the finite series *)
+      rewrite SeriesC_finite_mass fin_card.
+      rewrite -Rmult_assoc Rinv_r; try auto.
+      lra.
+    }
+
+    (* Multiply everything by S N*)
+    apply (Rmult_eq_reg_l (INR (S N))); [| apply not_0_INR;lia].
+    rewrite Rmult_plus_distr_l -Rmult_assoc /Rdiv.
+    rewrite Rmult_1_l Rinv_r; [| apply not_0_INR;lia].
+    rewrite Rmult_1_l.
+    rewrite -Rmult_assoc (Rmult_comm _ ( / INR (S N))) -Rmult_assoc.
+    rewrite Rinv_r; [| apply not_0_INR;lia].
+    rewrite Rmult_1_l.
+
+    (* Turn everything into fR and k by dividing out 𝜀*)
+    rewrite /εR. Opaque fR. simpl nonneg.
+    do 2 rewrite (Rmult_comm (INR _)) Rmult_assoc.
+    rewrite -Rmult_plus_distr_l.
+    apply Rmult_eq_compat_l.
+
+    (* apply fR_mean and conclude *)
+    rewrite (Rmult_comm _ (INR (S N))).
+    rewrite (fR_mean N); try lia.
+    lra.
+  Qed.
+End seq_ampl.

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -541,18 +541,34 @@ Admitted.
 
 
 (** * Approximate Lifting *)
-(* see ARcoupl_state_state  *)
-Lemma ub_lift_state (N : nat) 𝜎 𝛼 ns (ε : nonnegreal) :
+(* FIXME: clean up *)
+Lemma ub_lift_state (N : nat) 𝜎 𝛼 ns :
   𝜎.(tapes) !! 𝛼 = Some (N; ns) →
   ub_lift
     (state_step 𝜎 𝛼)
     (fun 𝜎' => exists (n : fin (S N)), 𝜎' = state_upd_tapes <[𝛼 := (N; ns ++ [n])]> 𝜎)
-    ε.
+    nnreal_zero.
 Proof.
-
-
-
-Admitted.
+  rewrite /ub_lift.
+  intros Htapes P Hp.
+  apply Req_le_sym; simpl.
+  rewrite /prob SeriesC_0; auto.
+  intros 𝜎'.
+  remember (negb (P 𝜎')) as K; destruct K; auto.
+  rewrite /state_step.
+  case_bool_decide.
+  2: { exfalso. apply H. by apply elem_of_dom. }
+  intros.
+  replace (lookup_total 𝛼 (tapes 𝜎)) with (N; ns).
+  2: { rewrite (lookup_total_correct _ _ (existT N ns)); auto.  }
+  apply dmap_unif_zero.
+  intros n Hcont.
+  apply diff_true_false.
+  specialize Hp with 𝜎'.
+  rewrite -Hp; [| by exists n].
+  replace false with (negb true) by auto.
+  by rewrite HeqK negb_involutive.
+Qed.
 
 (** adapted from wp_couple_tapes in the relational logic *)
 Lemma wp_presample (N : nat) E e 𝛼 ns Φ :

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -167,7 +167,6 @@ Proof.
   iIntros (σ1 ε) "[Hσ Hε]".
   iApply fupd_mask_intro; [set_solver|].
   iIntros "Hclose'".
-  solve_red.
   iDestruct (ec_supply_bound with "Hε Herr ") as %Hle.
   set (ε' := nnreal_minus ε (nnreal_inv (nnreal_nat (Z.to_nat z + 1))) Hle ).
   replace ε with (nnreal_plus (nnreal_inv (nnreal_nat (Z.to_nat z + 1))) ε'); last first.
@@ -176,6 +175,8 @@ Proof.
   iExists
       (λ (ρ : expr * state),
         ∃ (n : fin (S (Z.to_nat z))), n ≠ m /\ ρ = (Val #n, σ1)), _, _.
+  iSplit.
+  { iPureIntro. solve_red. }
   iSplit.
   {
     iPureIntro.
@@ -223,7 +224,6 @@ Proof.
   iIntros (σ1 ε) "[Hσ Hε]".
   iApply fupd_mask_intro; [set_solver|].
   iIntros "Hclose'".
-  solve_red.
   iDestruct (ec_supply_bound with "Hε Herr ") as %Hle.
   set (ε' := nnreal_minus ε (nnreal_inv (nnreal_nat (Z.to_nat z + 1))) Hle ).
   replace ε with (nnreal_plus (nnreal_inv (nnreal_nat (Z.to_nat z + 1))) ε'); last first.
@@ -232,6 +232,7 @@ Proof.
   iExists
       (λ (ρ : expr * state),
         ∃ (n : fin (S (Z.to_nat z))), fin_to_nat n ≠ m /\ ρ = (Val #n, σ1)),_,_.
+  iSplit. { iPureIntro. solve_red. }
   iSplit.
   {
     iPureIntro; apply Rle_refl.
@@ -278,7 +279,6 @@ Proof.
   iIntros (σ1 ε) "[Hσ Hε]".
   iApply fupd_mask_intro; [set_solver|].
   iIntros "Hclose'".
-  solve_red.
   iDestruct (ec_supply_bound with "Hε Herr ") as %Hle.
   set (ε' := nnreal_minus ε (nnreal_div (nnreal_nat (length ns)) (nnreal_nat (Z.to_nat z + 1))) Hle ).
   replace ε with (nnreal_plus (nnreal_div (nnreal_nat (length ns)) (nnreal_nat (Z.to_nat z + 1))) ε'); last first.
@@ -287,6 +287,7 @@ Proof.
   iExists
       (λ (ρ : expr * state),
         ∃ (n : fin (S (Z.to_nat z))), Forall (λ m, fin_to_nat n ≠ m) ns /\ ρ = (Val #n, σ1)),_,_.
+  iSplit. {iPureIntro. solve_red. }
   iSplit.
   {
     iPureIntro; apply Rle_refl.
@@ -333,7 +334,6 @@ Proof.
   iIntros (σ1 ε) "[Hσ Hε]".
   iApply fupd_mask_intro; [set_solver|].
   iIntros "Hclose'".
-  solve_red.
   iDestruct (ec_supply_bound with "Hε Herr ") as %Hle.
   set (ε' := nnreal_minus ε (nnreal_div (nnreal_nat (length zs)) (nnreal_nat (Z.to_nat z + 1))) Hle ).
   replace ε with (nnreal_plus (nnreal_div (nnreal_nat (length zs)) (nnreal_nat (Z.to_nat z + 1))) ε'); last first.
@@ -342,6 +342,7 @@ Proof.
   iExists
       (λ (ρ : expr * state),
         ∃ (n : fin (S (Z.to_nat z))), Forall (λ m, Z.of_nat (fin_to_nat n) ≠ m) zs /\ ρ = (Val #n, σ1)),_,_.
+  iSplit. { iPureIntro. solve_red. }
   iSplit.
   {
     iPureIntro; apply Rle_refl.
@@ -425,7 +426,6 @@ Proof.
   iIntros (σ1 ε_now) "[Hσ Hε]".
   iApply fupd_mask_intro; [set_solver|].
   iIntros "Hclose'".
-  solve_red.
   iApply exec_ub_adv_comp; simpl.
   iDestruct (ec_split_supply with "Hε Herr") as (ε3) "%Hε3".
   (* ε3 is the amount of credit supply left outside of ε1 (?) *)
@@ -445,6 +445,7 @@ Proof.
   iExists
       (λ (ρ : expr * state),
         ∃ (n : fin (S (Z.to_nat z))), ρ = (Val #n, σ1)), nnreal_zero, foo.
+  iSplit. { iPureIntro. solve_red. }
   iSplit.
   {
     iPureIntro. exists (ε3 + r)%R.
@@ -610,24 +611,22 @@ Qed.
 (** adapted from wp_couple_tapes in the relational logic *)
 Lemma wp_presample (N : nat) E e 𝛼 ns Φ :
   to_val e = None →
-  (∀ σ', reducible e σ') →
   ▷ 𝛼 ↪ (N; ns) ∗
   (∀ (n : fin (S N)), 𝛼 ↪ (N; ns ++ [n]) -∗ WP e @ E {{ Φ }})
   ⊢ WP e @ E {{ Φ }}.
 Proof.
-    iIntros (He Hred) "(>H𝛼&Hwp)".
+    iIntros (He) "(>H𝛼&Hwp)".
     iApply wp_lift_step_fupd_exec_ub; [done|].
     iIntros (𝜎 ε) "((Hheap&Htapes)&Hε)".
     iDestruct (ghost_map_lookup with "Htapes H𝛼") as %Hlookup.
     iApply fupd_mask_intro; [set_solver|]; iIntros "Hclose'".
-    iSplitR; [done|].
     (* now we need to prove an exec_ub, we should be able to do this with a state step. *)
     replace ε with (nnreal_zero + ε)%NNR by (apply nnreal_ext; simpl; lra).
     iApply exec_ub_state_step.
     { rewrite /= /get_active.
       by apply elem_of_list_In, elem_of_list_In, elem_of_elements, elem_of_dom. }
     iExists _.
-    iSplit.
+    iSplitR.
     { iPureIntro. apply ub_lift_state, Hlookup. }
     iIntros (𝜎') "[%n %H𝜎']".
     (* now we have to prove the exec_ub about 𝜎', we should be able to do this with the wp *)
@@ -638,7 +637,7 @@ Proof.
     iSpecialize ("Hwp" $! n with "H𝛼").
     rewrite !ub_wp_unfold /ub_wp_pre /= He.
     iSpecialize ("Hwp" $! 𝜎' ε).
-    iMod ("Hwp" with "[Hheap Htapes Hε]") as "(?&Hwp)".
+    iMod ("Hwp" with "[Hheap Htapes Hε]") as "Hwp".
     { replace (nnreal_zero + ε)%NNR with ε by (apply nnreal_ext; simpl; lra).
       rewrite H𝜎'.
       iFrame.
@@ -667,30 +666,6 @@ refine(
 Defined.
 
 
-Lemma compute_ε2_in_state_expr e σ N z ε2 H :
-  to_val e = None ->
-  compute_ε2_in_state (e, σ) N z ε2 H = nnreal_zero.
-Proof.
-  intros; rewrite /compute_ε2_in_state; simpl.
-  case_match; auto.
-  simplify_eq.
-Qed.
-
-
-Check (fun (s : state) => s.(tapes)).
-Check (fun α z ns sample=> (state_upd_tapes <[α:=(Z.to_nat z; ns ++ [sample]) : tape]> )).
-Check (fun σ σ' α z ns N => (exists s : fin _, σ' = (state_upd_tapes <[α:=(Z.to_nat z; ns ++ [s]) : tape]> σ))).
-Check (fun σ σ' α z ns N =>
-            match exists_dec (fun s : fin _ => σ' = (state_upd_tapes <[α:=(Z.to_nat z; ns ++ [s]) : tape]> σ)) with
-                | left H => _ H
-                | right H => nnreal_zero
-              end).
-
-(* I'll admit this for now to see if the rest of the proof works  *)
-
-(* really this should not depend on the expr at all :/*)
-
-
 Definition compute_ε2 (σ : state) (ρ : cfg) α N ns (ε2 : fin (S N) -> nonnegreal) : nonnegreal :=
   match finite.find (fun s => state_upd_tapes <[α:=(N; ns ++ [s]) : tape]> σ = snd ρ) with
     | Some s => ε2 s
@@ -702,21 +677,19 @@ Lemma wp_presample_adv_comp (N : nat) α (ns : list (fin (S N))) z e E Φ (ε1 :
   E = ∅ -> (* can this really only be proven when E = ∅ or can we improve this? *)
   TCEq N (Z.to_nat z) →
   to_val e = None →
-  (∀ σ', reducible e σ') →
   SeriesC (λ n, (1 / (S N)) * ε2 n)%R = (nonneg ε1) →
   α ↪ (N; ns) ∗
   € ε1 ∗
   (∀ (n : fin (S N)), € (ε2 n) ∗ α ↪ (N; ns ++ [n]) -∗ WP e @ E {{ Φ }})
   ⊢ WP e @ E {{ Φ }}.
 Proof.
-  iIntros (? -> Hred Hσ_red Hsum) "(Hα & Hε & Hwp)".
+  iIntros (? -> Hσ_red Hsum) "(Hα & Hε & Hwp)".
   iApply wp_lift_step_fupd_exec_ub; [done|].
   iIntros (σ1 ε_now) "[(Hheap&Htapes) Hε_supply]".
   iDestruct (ghost_map_lookup with "Htapes Hα") as %Hlookup.
   iDestruct (ec_supply_bound with "Hε_supply Hε") as %Hε1_ub.
   iApply fupd_mask_intro; [set_solver|].
   iIntros "Hclose".
-  iSplitR; [auto|].
   iApply (exec_ub_state_adv_comp' α); simpl.
   { rewrite /get_active.
     apply elem_of_list_In, elem_of_list_In, elem_of_elements, elem_of_dom.
@@ -850,25 +823,25 @@ Proof.
   iMod (ec_increase_supply _ (ε2 sample) with "Hε_supply") as "[Hε_supply Hε]".
   iMod (ghost_map_update ((Z.to_nat z; ns ++ [sample]) : tape) with "Htapes Hα") as "[Htapes Hα]".
   iSpecialize ("Hwp" $! sample).
-
   (* open the WP and specialize it to get the goal *)
   rewrite ub_wp_unfold /ub_wp_pre.
   iAssert (⌜ (common.language.to_val e) = None ⌝)%I as "%X". { auto. }
   rewrite X; clear X.
   (* then we should be able to specialize using the updated ghost state.. *)
 
-  iAssert (⌜reducible e {| heap := heap2; tapes := tapes2 |}⌝ ={∅,E}=∗ emp)%I with "[Hclose]" as "HcloseW".
-  { iIntros; iFrame. }
+  (* iAssert (⌜reducible e {| heap := heap2; tapes := tapes2 |}⌝ ={∅,E}=∗ emp)%I with "[Hclose]" as "HcloseW".
+  { iIntros; iFrame. } *)
 
+  (*
   iPoseProof (fupd_trans_frame E ∅ E _ (⌜reducible e {| heap := heap2; tapes := tapes2 |}⌝))%I as "HR".
-  iSpecialize ("HR" with "[Hwp Hheap Hε_supply Hε Htapes Hα HcloseW]").
+  iSpecialize ("HR" with "[Hwp Hheap Hε_supply Hε Htapes Hα Hclose]").
   { iFrame.
     iApply ("Hwp" with "[Hε Hα]"). { iFrame. }
     rewrite /state_interp /=.
     rewrite /state_upd_tapes in Hsample.
     inversion Hsample.
     iFrame. }
-
+    *)
   rewrite Hsample /compute_ε2 /=.
   destruct (@find_is_Some _ _ _
                (λ s : fin (S (Z.to_nat z)), state_upd_tapes <[α:=(Z.to_nat z; ns ++ [s])]> σ1 = state_upd_tapes <[α:=(Z.to_nat z; ns ++ [sample])]> σ1)
@@ -888,11 +861,22 @@ Proof.
     apply app_inv_head in Heqt.
     by inversion Heqt. }
 
-  iApply fupd_mask_mono; last done.
+  (* iSpecialize ("Hwp" with "[Hwp Hheap Hε_supply Hε Htapes Hα HcloseW]"). *)
+  iSpecialize ("Hwp" with "[Hε Hα]"); first iFrame.
+  remember {| heap := heap2; tapes := tapes2 |} as σ2.
+  iSpecialize ("Hwp" $! σ2 _).
+  iSpecialize ("Hwp" with "[Hheap Htapes Hε_supply]").
+  { iSplitL "Hheap Htapes".
+    - rewrite /tapes_auth.
+      rewrite Heqσ2 in Hsample. inversion Hsample.
+      simplify_eq. simpl. iFrame.
+    - iFrame. }
 
+  rewrite -Hsample.
   (* FIXME I can't see where this could be improved in the proof, but I also see no reason why it could't.
       (related to the prophecy counterexample? idk. )*)
-  set_solver.
+  simplify_eq.
+  done.
 Qed.
 
 
@@ -981,7 +965,6 @@ Lemma presample_amplify' N z L e E Φ kwf prefix (suffix_total suffix_remaining 
   E = ∅ ->
   TCEq N (Z.to_nat z) →
   to_val e = None →
-  (∀ σ', reducible e σ') →
   L = length suffix_total ->
   (0 < L)%nat ->
   (α ↪ (N; prefix) ∗
@@ -992,7 +975,7 @@ Lemma presample_amplify' N z L e E Φ kwf prefix (suffix_total suffix_remaining 
          -∗ WP e @ E {{ Φ }})
       -∗ WP e @ E {{ Φ }}))%I.
 Proof.
-  iIntros (? ? ? ? Htotal HLpos) "(Htape & Hcr_initial)".
+  iIntros (? ? ? Htotal HLpos) "(Htape & Hcr_initial)".
   iIntros (i HL).
   iInduction i as [|i'] "IH" forall (suffix_remaining).
   - iIntros "Hwp"; iApply "Hwp".
@@ -1035,14 +1018,13 @@ Lemma wp_presample_amplify N z L e E Φ prefix suffix α (ε : posreal) (kwf: kw
   E = ∅ ->
   TCEq N (Z.to_nat z) →
   to_val e = None →
-  (∀ σ', reducible e σ') →
   L = (length suffix) ->
   € (pos_to_nn ε) ∗
   (α ↪ (N; prefix)) ∗
   ((α ↪ (N; prefix ++ suffix) ∨ (∃ junk, α ↪ (N; prefix ++ junk) ∗ €(εAmp N L ε kwf))) -∗ WP e @ E {{ Φ }})
   ⊢ WP e @ E {{ Φ }}.
 Proof.
-  iIntros (? ? ? ? Hl) "(Hcr & Htape & Hwp)".
+  iIntros (? ? ? Hl) "(Hcr & Htape & Hwp)".
   destruct suffix as [|s0 sr].
   - iApply "Hwp". iLeft. rewrite -app_nil_end. iFrame.
   - remember (s0 :: sr) as suffix.
@@ -1060,7 +1042,6 @@ Lemma seq_amplify N z L e E Φ d prefix suffix α (ε : posreal) (kwf: kwf N L) 
   E = ∅ ->
   TCEq N (Z.to_nat z) →
   to_val e = None →
-  (∀ σ', reducible e σ') →
   L = (length suffix) ->
   € (pos_to_nn ε) ∗
   (α ↪ (N; prefix)) ∗
@@ -1068,7 +1049,7 @@ Lemma seq_amplify N z L e E Φ d prefix suffix α (ε : posreal) (kwf: kwf N L) 
    -∗ WP e @ E {{ Φ }})
   ⊢ WP e @ E {{ Φ }}.
 Proof.
-  iIntros (? ? ? ? HL) "(Hcr&Htape&Hwp)".
+  iIntros (? ? ? HL) "(Hcr&Htape&Hwp)".
   iInduction (d) as [|d'] "IH".
   - iApply "Hwp".
     iExists []; rewrite app_nil_r. iRight. iFrame.
@@ -1091,13 +1072,12 @@ Lemma presample_planner_pos N z e E Φ prefix suffix α (ε : nonnegreal) (HN : 
   E = ∅ ->
   TCEq N (Z.to_nat z) →
   to_val e = None →
-  (∀ σ', reducible e σ') →
   € ε ∗
   (α ↪ (N; prefix)) ∗
   ((∃ junk, α ↪ (N; prefix ++ junk ++ suffix)) -∗ WP e @ E {{ Φ }})
   ⊢ WP e @ E {{ Φ }}.
 Proof.
-  iIntros (? ? ? ?) "(Hcr & Htape & Hwp)".
+  iIntros (? ? ?) "(Hcr & Htape & Hwp)".
   (* make the interface match the other coupling rules *)
   remember (length suffix) as L.
   assert (kwf : kwf N L). { apply mk_kwf; lia. }
@@ -1120,13 +1100,12 @@ Lemma presample_planner N z e E Φ prefix suffix α (ε : nonnegreal) (Hε : (0 
   E = ∅ ->
   TCEq N (Z.to_nat z) →
   to_val e = None →
-  (∀ σ', reducible e σ') →
   € ε ∗
   (α ↪ (S N; prefix)) ∗
   ((∃ junk, α ↪ (S N; prefix ++ junk ++ suffix)) -∗ WP e @ E {{ Φ }})
   ⊢ WP e @ E {{ Φ }}.
 Proof.
-  iIntros (? ? ? ?).
+  iIntros (? ? ?).
   destruct suffix as [|h R].
   - iIntros "(_ & Htape & Hwp)".
     iApply "Hwp".

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -775,8 +775,6 @@ Proof.
 
   (* decrease the supply to ε1 (to get rid of the € ε1) and then increase it to ε2.
      the decrease is probably not needed lol *)
-  iDestruct (ec_split_supply with "Hε_supply Hε") as (εrem) "%Hεrem".
-  simplify_eq.
   iMod (ec_decrease_supply with "Hε_supply Hε") as "Hε_supply".
   iMod (ec_increase_supply _ (ε2 sample) with "Hε_supply") as "[Hε_supply Hε]".
   iSpecialize ("Hwp" $! sample).
@@ -793,6 +791,8 @@ Proof.
 
   iAssert (state_interp (state_upd_tapes <[α:=(Z.to_nat z; ns ++ [sample]) : tape]> σ1)) with "[Hheap Htapes]" as "Hσ1".
   { rewrite /state_interp; iFrame. }
+
+  (*
   iAssert (err_interp (εrem + ε2 sample)%NNR ) with "[Hε_supply]" as "Hε_supply".
   { rewrite /err_interp; iFrame. }
   iSpecialize ("Hwp" with "[Hε Hα]").
@@ -800,6 +800,7 @@ Proof.
   iSpecialize ("Hwp" $! {| heap := heap2; tapes := tapes2 |} (εrem + ε2 sample)%NNR).
   iSpecialize ("Hwp" with "[Hσ1 Hε_supply]").
   { rewrite Hsample. iFrame. }
+*)
 
   (* oh no-- the nnreal_zero is wrong! it needs to be at least (εrem + r) *)
 

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -610,4 +610,18 @@ Proof.
 Qed.
 
 
+Lemma wp_presample_adv_comp (N : nat) 𝛼 ns z e E Φ (ε1 : nonnegreal) (ε2 : fin (S N) -> nonnegreal) :
+  TCEq N (Z.to_nat z) →
+  to_val e = None →
+  (∀ σ', reducible e σ') →
+  SeriesC (λ n, (1 / (S N)) * ε2 n)%R = (nonneg ε1) →
+  ▷ 𝛼 ↪ (N; ns) ∗
+  € ε1 ∗
+  (∀ (n : fin (S N)), € (ε2 n) ∗ 𝛼 ↪ (N; ns ++ [n]) -∗ WP e @ E {{ Φ }})
+  ⊢ WP e @ E {{ Φ }}.
+Proof.
+Admitted.
+
+
+
 End rules.

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -734,9 +734,8 @@ Proof.
           rewrite /state_upd_tapes in Hcont.
           assert (R1 : ((Z.to_nat z; ns ++ [sf]) : tape) = (Z.to_nat z; ns ++ [n0])).
           { apply (insert_inv (tapes σ1) α). by inversion Hcont. }
-
-          (* FIXME: is classical logic really necessary here? *)
-          apply classic_proof_irrel.PIT.EqdepTheory.inj_pair2, app_inv_head in R1.
+          apply Eqdep_dec.inj_pair2_eq_dec in R1; [|apply PeanoNat.Nat.eq_dec].
+          apply app_inv_head in R1.
           by inversion R1.
           Transparent INR.
       - rewrite /from_option /INR /=. lra.
@@ -784,8 +783,7 @@ Proof.
   { rewrite /state_upd_tapes in Hr.
     inversion Hr as [Heqt].
     apply (insert_inv (tapes σ1) α) in Heqt.
-    (* FIXME is classical necessary here? *)
-    apply classic_proof_irrel.PIT.EqdepTheory.inj_pair2 in Heqt.
+    apply Eqdep_dec.inj_pair2_eq_dec in Heqt; [|apply PeanoNat.Nat.eq_dec].
     apply app_inv_head in Heqt.
     by inversion Heqt. }
   remember {| heap := heap2; tapes := tapes2 |} as σ2.

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -632,9 +632,7 @@ Defined.
 
 Lemma SeriesC_singleton_dependent `{Countable A} (a : A) (v : A -> nonnegreal) :
   SeriesC (λ n, if bool_decide (n = a) then v n else nnreal_zero) = nonneg (v a).
-Proof. (* proven in other branch *)
-Admitted.
-
+Proof. (* proven in other branch *) Admitted.
 
 
 Lemma wp_presample_adv_comp (N : nat) α (ns : list (fin (S N))) z e E Φ (ε1 : nonnegreal) (ε2 : fin (S N) -> nonnegreal) :

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -377,10 +377,9 @@ Proof.
   done.
 Qed.
 
-(* FIXME: merge me from other branch *)
-Lemma SeriesC_singleton_dependent `{Countable A} (a : A) (v : A -> nonnegreal) :
-  SeriesC (λ n, if bool_decide (n = a) then v n else nnreal_zero) = nonneg (v a).
-Proof.  Admitted.
+(* FIXME: where should this go (if anywhere?) *)
+Lemma match_nonneg_coercions (n : nonnegreal) : NNRbar_to_real (NNRbar.Finite n) = nonneg n.
+Proof. by simpl. Qed.
 
 Lemma mean_constraint_ub (N : nat) ε1 (ε2 : fin (S N) -> nonnegreal) :
   SeriesC (λ n, (1 / (S N)) * ε2 n)%R = (nonneg ε1) ->
@@ -403,7 +402,8 @@ Proof.
     replace (nonneg {| nonneg := INR (S N); cond_nonneg := _ |}) with (INR (S N)); [| by simpl ].
     apply not_0_INR.
     auto.
-  - rewrite -(SeriesC_singleton_dependent _ ε2).
+  - rewrite -match_nonneg_coercions.
+    rewrite -(SeriesC_singleton_dependent _ ε2).
     apply SeriesC_le.
     + intros n'.
       assert (H : (0 <= (nonneg (ε2 n')))%R) by apply cond_nonneg.
@@ -413,8 +413,6 @@ Proof.
 Qed.
 
 
-Lemma match_nonneg_coercions (n : nonnegreal) : NNRbar_to_real (NNRbar.Finite n) = nonneg n.
-Proof. by simpl. Qed.
 
 
 Lemma wp_couple_rand_adv_comp (N : nat) z E Φ (ε1 : nonnegreal) (ε2 : fin (S N) -> nonnegreal) :
@@ -898,5 +896,176 @@ Proof.
   set_solver.
 Qed.
 
+
+(*
+Lemma ec_spend_irrel ε1 ε2 : (ε1.(nonneg) = ε2.(nonneg)) → € ε1 -∗ € ε2.
+Proof.
+  iIntros (?) "?".
+  replace ε1 with ε2; first by iFrame.
+  by apply nnreal_ext.
+Qed.
+
+Lemma ec_spend_1 ε1 : (1 <= ε1.(nonneg))%R → € ε1 -∗ False.
+Proof. Admitted.
+
+(** advanced composition on one tape *)
+(* not really sure what this lemma will look like in the real version? *)
+Lemma presample_adv_comp (N : nat) α ns (ε : nonnegreal) (ε2 : fin (S N) -> nonnegreal) :
+  SeriesC (λ n, (1 / (S N)) * ε2 n)%R = (nonneg ε) →
+  (α ↪ (N; ns) ∗ € ε) -∗ (∃ s, (α ↪ (N; ns ++ [s])) ∗ €(ε2 s)).
+Proof. Admitted.
+
+Lemma amplification_depth N L (ε : posreal) (kwf : kwf N L) : exists n : nat, (1 <= ε * (k N L kwf) ^ n)%R.
+Proof.
+  (* shouldn't be too hard, it's the log *)
+Admitted.
+
+
+Lemma lookup_ex {A} (n : nat) (L : list A) : (n < length L)%nat -> exists x, (L !! n) = Some x.
+Proof.
+  (* can't figure out how to do this with existing lemmas! *)
+  intros HL.
+  destruct L as [|h H]; [simpl in HL; lia|].
+  generalize dependent H. generalize dependent h.
+  induction n as [|n' IH].
+  - intros h ? ?. exists h; by simpl.
+  - intros h H HL.
+    rewrite cons_length in HL; apply Arith_prebase.lt_S_n in HL.
+    destruct H as [|h' H']; [simpl in HL; lia|].
+    replace ((h :: h' :: H') !! S n') with ((h' :: H') !! n'); last by simpl.
+    by apply IH.
+Qed.
+
+
+(* whenever i is strictly less than l (ie, (S i) <= l) we can amplify *)
+(* we'll need another rule for spending?, but that should be simple *)
+Lemma presample_amplify' N L kwf prefix (suffix_total suffix_remaining : list (fin (S N))) 𝛼 (ε : posreal) :
+  ⊢ ⌜ L = length suffix_total ⌝ →
+    ⌜ (0 < L)%nat ⌝ →
+    𝛼 ↪ (N; prefix) -∗
+    (€ (pos_to_nn ε)) -∗
+    ∀ (i : nat),
+      (∀ (HL : (i <= L)%nat),
+          (∃ junk, 𝛼 ↪ (N; prefix ++ junk) ∗ €(εAmp N L ε kwf)) ∨
+          ((𝛼 ↪ (N; prefix ++ (take i suffix_total))) ∗
+            € (εR N L i ε (mk_fRwf N L i kwf HL)))).
+Proof.
+  iIntros (Htotal HLpos) "Htape Hcr_initial"; iIntros (i).
+  iInduction i as [|i'] "IH" forall (suffix_remaining).
+  - iIntros (HL).
+    iRight. iSplitL "Htape".
+    + rewrite take_0 -app_nil_end. iFrame.
+    + iApply ec_spend_irrel; last iFrame.
+      rewrite /εR /fR /pos_to_nn /=; lra.
+  - iIntros "%HL".
+    assert (HL' : (i' <= L)%nat) by lia.
+    iSpecialize ("IH" $! _ with "Htape Hcr_initial").
+    iSpecialize ("IH" $! HL').
+    iDestruct "IH" as "[[%junk(Htape&Hcr)]|(Htape&Hcr)]".
+    + iLeft; iExists junk; iFrame.
+    +
+      (* we need to do something different dependning on if (S i') is L? No. in that case we still need 1 amp*)
+      assert (Hi' : (i' < length suffix_total)%nat) by lia.
+      destruct (lookup_ex i' suffix_total Hi') as [target Htarget].
+      rewrite (take_S_r _ _ target); [|apply Htarget].
+      pose M := (εDistr_mean N L i' ε target (mk_fRwf N L (S i') kwf HL)).
+      iPoseProof (presample_adv_comp N 𝛼
+                   (prefix ++ take i' suffix_total)
+                   (εR N L i' ε (fRwf_dec_i N L i' _)) (εDistr N L i' ε target _) M) as "PS".
+      replace {| k_wf := kwf; i_ub := HL' |} with(fRwf_dec_i N L i' {| k_wf := kwf; i_ub := HL |});
+        last by apply fRwf_ext.
+      iSpecialize ("PS" with "[Htape Hcr]"); first iFrame.
+      iDestruct "PS" as "[%s (Htape&Hcr)]".
+      (* NOW we can destruct and decide if we're left or right *)
+      rewrite /εDistr.
+      case_bool_decide.
+      * iRight. rewrite H app_assoc. iFrame.
+      * iLeft. iExists (take i' suffix_total ++ [s]).
+        replace (k_wf N L (S i') {| k_wf := kwf; i_ub := HL |}) with kwf; last by apply kwf_ext.
+        rewrite -app_assoc; iFrame.
+    Unshelve. auto.
+Qed.
+
+(* do one step in the amplification sequence *)
+Lemma presample_amplify N L prefix suffix 𝛼 (ε : posreal) (kwf: kwf N L) :
+  L = (length suffix) ->
+  € (pos_to_nn ε) -∗
+  (𝛼 ↪ (N; prefix)) -∗
+  (𝛼 ↪ (N; prefix ++ suffix) ∨ (∃ junk, 𝛼 ↪ (N; prefix ++ junk) ∗ €(εAmp N L ε kwf))).
+Proof.
+  iIntros (Hl) "Hcr Htape".
+
+  destruct suffix as [|s0 sr].
+  - iLeft. rewrite -app_nil_end. iFrame.
+  - remember (s0 :: sr) as suffix.
+    assert (Hl_pos : (0 < L)%nat).
+    { rewrite Hl Heqsuffix cons_length. lia. }
+    iPoseProof (presample_amplify' N L _ prefix suffix suffix 𝛼 ε $! Hl Hl_pos) as "X".
+    iSpecialize ("X" with "Htape Hcr").
+    iSpecialize ("X" $! L (le_n L)).
+    iDestruct "X" as "[H|(H&_)]".
+    + iRight. iApply "H".
+    + iLeft. rewrite Hl firstn_all. iFrame.
+Qed.
+
+
+Lemma seq_amplify N L d prefix suffix 𝛼 (ε : posreal) (kwf: kwf N L) :
+  L = (length suffix) ->
+  € (pos_to_nn ε) -∗
+  (𝛼 ↪ (N; prefix)) -∗
+  (∃ junk,
+      𝛼 ↪ (N; prefix ++ junk ++ suffix) ∨ 𝛼 ↪ (N; prefix ++ junk) ∗ €(pos_to_nn (εAmp_iter N L d ε kwf))).
+Proof.
+  iIntros (HL) "Hcr Htape".
+  iInduction (d) as [|d'] "IH".
+  - iExists []; rewrite app_nil_r. iRight. iFrame.
+    iApply ec_spend_irrel; last auto.
+    by rewrite /εAmp_iter /pos_to_nn /= Rmult_1_r.
+  - iDestruct ("IH" with "Hcr Htape") as "[%junk [Hlucky|(Htape&Hcr)]]".
+    + iExists junk; iLeft; iFrame.
+    + rewrite -εAmp_iter_cmp.
+      iPoseProof (presample_amplify N L (prefix ++ junk) suffix 𝛼 (εAmp_iter N L d' ε kwf)) as "X"; try auto.
+      iDestruct ("X" with "Hcr Htape") as "[Hlucky|[%junk' (Htape&Hcr)]]".
+      * iExists junk; iLeft. rewrite -app_assoc; iFrame.
+      * iExists (junk ++ junk'); iRight.
+        rewrite app_assoc; iFrame.
+Qed.
+
+
+Lemma presample_planner_pos N prefix suffix 𝛼 ε (HN : (0 < N)%nat) (HL : (0 < (length suffix))%nat) (Hε : (0 < ε)%R) :
+  € ε -∗
+  (𝛼 ↪ (N; prefix)) -∗
+  (∃ junk, 𝛼 ↪ (N; prefix ++ junk ++ suffix)).
+Proof.
+  iIntros "Hcr Htape".
+  (* make the interface match the other coupling rules *)
+  remember (length suffix) as L.
+  assert (kwf : kwf N L). { apply mk_kwf; lia. }
+  pose ε' := mkposreal ε.(nonneg) Hε.
+  replace ε with (pos_to_nn ε'); last first.
+  { rewrite /ε' /pos_to_nn. by apply nnreal_ext. }
+
+  destruct (amplification_depth N L ε' kwf) as [d Hdepth].
+  iDestruct ((seq_amplify N L d prefix suffix 𝛼 ε' kwf) with "Hcr Htape") as "[%junk [?|(_&Hcr)]]"; auto.
+  iExFalso; iApply ec_spend_1; last iFrame.
+  Set Printing Coercions.
+  rewrite /pos_to_nn /εAmp_iter /=.
+  replace (nonneg ε) with (pos ε') by auto.
+  done.
+Qed.
+
+Lemma presample_planner N prefix suffix 𝛼 ε (Hε : (0 < ε)%R) :
+  € ε -∗
+  (𝛼 ↪ (S N; prefix)) -∗
+  (∃ junk, 𝛼 ↪ (S N; prefix ++ junk ++ suffix)).
+Proof.
+  destruct suffix as [|h R].
+  - iIntros "_ Htape". iExists []. do 2 (rewrite -app_nil_end); iFrame.
+  - remember (h :: R) as suffix.
+    iApply presample_planner_pos; auto; try lia.
+    rewrite Heqsuffix cons_length.
+    lia.
+Qed.
+*)
 
 End rules.

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -911,7 +911,6 @@ Proof.
   rewrite ub_wp_unfold /ub_wp_pre /= Hred.
   iIntros (σ1 ε0) "(_&Hε_supply)".
   iExFalso.
-  (* we'd need *)
 Abort.
 
 Lemma ec_spend_1 ε1 : (1 <= ε1.(nonneg))%R → € ε1 -∗ False.

--- a/theories/ub_logic/ub_weakestpre.v
+++ b/theories/ub_logic/ub_weakestpre.v
@@ -553,7 +553,7 @@ Section exec_ub.
     (α ∈ get_active σ1 ->
      (∃ R (ε2 : cfg Λ -> nonnegreal),
         ⌜ exists r, forall ρ, (ε2 ρ <= r)%R ⌝ ∗
-        ⌜ (SeriesC (λ ρ, (state_step σ1 α ρ) * ε2 (e1, ρ)) = ε)%R ⌝ ∗
+        ⌜ (SeriesC (λ ρ, (state_step σ1 α ρ) * ε2 (e1, ρ)) <= ε)%R ⌝ ∗
         ⌜ub_lift (state_step σ1 α) R nnreal_zero⌝ ∗
         ∀ σ2, ⌜ R σ2 ⌝ ={∅}=∗ exec_ub e1 σ2 Z (ε2 (e1, σ2)))
       ⊢ exec_ub e1 σ1 Z ε)%I.
@@ -565,7 +565,7 @@ Section exec_ub.
     iExists _,nnreal_zero,_.
     iSplit; [auto|].
     iSplit.
-    { iPureIntro. apply Req_le. rewrite Hε /=. lra. }
+    { iPureIntro. by rewrite /= Rplus_0_l. }
     iSplit; [done|done].
   Qed.
 

--- a/theories/ub_logic/ub_weakestpre.v
+++ b/theories/ub_logic/ub_weakestpre.v
@@ -48,17 +48,24 @@ Section exec_ub.
     (λ (x : nonnegreal * cfg Λ),
       let '(ε, (e1, σ1)) := x in
       (* [prim_step] *)
-      (∃ R (ε1 ε2 : nonnegreal), ⌜ (ε1 + ε2 <= ε)%R ⌝ ∗ ⌜ub_lift (prim_step e1 σ1) R ε1⌝ ∗
+      (∃ R (ε1 ε2 : nonnegreal),
+          ⌜reducible e1 σ1⌝ ∗
+          ⌜ (ε1 + ε2 <= ε)%R ⌝ ∗
+          ⌜ub_lift (prim_step e1 σ1) R ε1⌝ ∗
             ∀ ρ2, ⌜ R ρ2 ⌝ ={∅}=∗ Z ε2 ρ2 ) ∨
       (* [prim_step] with adv composition *)
       (∃ R (ε1 : nonnegreal) (ε2 : cfg Λ -> nonnegreal),
+          ⌜reducible e1 σ1⌝ ∗
           ⌜ exists r, forall ρ, (ε2 ρ <= r)%R ⌝ ∗
           ⌜ (ε1 + SeriesC (λ ρ, (prim_step e1 σ1 ρ) * ε2(ρ)) <= ε)%R ⌝ ∗ ⌜ub_lift (prim_step e1 σ1) R ε1⌝ ∗
             ∀ ρ2, ⌜ R ρ2 ⌝ ={∅}=∗ Z (ε2 ρ2) ρ2 ) ∨
       (* [state_step]  *)
       ([∨ list] α ∈ get_active σ1,
       (* We allow an explicit weakening of the grading, but maybe it is not needed *)
-        (∃ R (ε1 ε2 : nonnegreal), ⌜ (ε1 + ε2 <= ε)%R ⌝ ∗ ⌜ ub_lift (state_step σ1 α) R ε1 ⌝ ∗
+        (∃ R (ε1 ε2 : nonnegreal),
+            ⌜reducible e1 σ1⌝ ∗
+            ⌜ (ε1 + ε2 <= ε)%R ⌝ ∗
+            ⌜ ub_lift (state_step σ1 α) R ε1 ⌝ ∗
               ∀ σ2, ⌜ R σ2 ⌝ ={∅}=∗ Φ (ε2,((e1, σ2))))) ∨
       (* [state_step] with adv composition*)
       ([∨ list] α ∈ get_active σ1,
@@ -93,9 +100,10 @@ Section exec_ub.
       iInduction (get_active σ1) as [| l] "IH" forall "H".
       { rewrite big_orL_nil //. }
       rewrite !big_orL_cons.
-      iDestruct "H" as "[(% & % & % & %Hsum & Hlift & HΦ) | H]".
+      iDestruct "H" as "[(% & % & % & %Hred & %Hsum & %Hlift & HΦ) | H]".
       + iLeft. iExists R2.
         iExists ε1. iExists _.
+        iSplit; [try done|].
         iSplit; [try done|].
         iSplit; [try done|].
         iIntros. iApply "Hwand". by iApply "HΦ".
@@ -119,14 +127,21 @@ Section exec_ub.
 
   Lemma exec_ub_unfold e1 σ1 Z ε :
     exec_ub e1 σ1 Z ε ≡
-      ((∃ R (ε1 ε2 : nonnegreal), ⌜ (ε1 + ε2 <= ε)%R ⌝ ∗ ⌜ub_lift (prim_step e1 σ1) R ε1⌝ ∗
+      ((∃ R (ε1 ε2 : nonnegreal),
+           ⌜reducible e1 σ1⌝ ∗
+           ⌜ (ε1 + ε2 <= ε)%R ⌝ ∗
+           ⌜ub_lift (prim_step e1 σ1) R ε1⌝ ∗
             ∀ ρ2, ⌜ R ρ2 ⌝ ={∅}=∗ Z ε2 ρ2 ) ∨
       (∃ R (ε1 : nonnegreal) (ε2 : cfg Λ -> nonnegreal),
+          ⌜reducible e1 σ1⌝ ∗
           ⌜ exists r, forall ρ, (ε2 ρ <= r)%R ⌝ ∗
           ⌜ (ε1 + SeriesC (λ ρ, (prim_step e1 σ1 ρ) * ε2(ρ)) <= ε)%R ⌝ ∗ ⌜ub_lift (prim_step e1 σ1) R ε1⌝ ∗
             ∀ ρ2, ⌜ R ρ2 ⌝ ={∅}=∗ Z (ε2 ρ2) ρ2 ) ∨
       ([∨ list] α ∈ get_active σ1,
-        (∃ R (ε1 ε2 : nonnegreal), ⌜ (ε1 + ε2 <= ε)%R ⌝ ∗ ⌜ ub_lift (state_step σ1 α) R ε1 ⌝ ∗
+        (∃ R (ε1 ε2 : nonnegreal),
+            ⌜reducible e1 σ1⌝ ∗
+            ⌜ (ε1 + ε2 <= ε)%R ⌝ ∗
+            ⌜ ub_lift (state_step σ1 α) R ε1 ⌝ ∗
               ∀ σ2, ⌜ R σ2 ⌝ ={∅}=∗ exec_ub e1 σ2 Z ε2 )) ∨
       ([∨ list] α ∈ get_active σ1,
         (∃ R (ε1 : nonnegreal) (ε2 : cfg Λ -> nonnegreal),
@@ -151,24 +166,26 @@ Section exec_ub.
     iPoseProof (least_fixpoint_ind (exec_ub_pre Z) Φ with "[]") as "H"; last first.
     { iApply ("H" with "H_ub"). }
     iIntros "!#" ([ε'' [? σ']]). rewrite /exec_ub_pre.
-    iIntros "[ (% & % & % & % & H) | [ (% & % & % & % & % & % & H) | [ H | H ]]] %ε3 %Hleq' /="; simpl in Hleq'.
+    iIntros "[ (% & % & % & % & % & % & H) | [ (% & % & % & % & % & % & % & H) | [ H | H ]]] %ε3 %Hleq' /="; simpl in Hleq'.
     - rewrite least_fixpoint_unfold.
       iLeft. iExists _,_,_.
-      iSplit; [|done].
-      iPureIntro; etrans; done.
+      iSplit; [done|].
+      iSplit; [iPureIntro; etrans; done|].
+      iSplit; [done|].
+      done.
     - rewrite least_fixpoint_unfold.
       iRight;iLeft. iExists _,_,_.
-      iSplit; [|iSplit; [| iSplit]].
-      1,3,4:done.
+      iSplit; [|iSplit; [| iSplit; [| iSplit]]]; try done.
       iPureIntro; etrans; done.
     - rewrite least_fixpoint_unfold.
       iRight; iRight; iLeft.
       iInduction (get_active σ') as [| l] "IH".
       { rewrite big_orL_nil //. }
       rewrite 2!big_orL_cons.
-      iDestruct "H" as "[(%R2 & %ε1 & %ε2 & (%Hleq2 & %Hub & H)) | Ht]".
+      iDestruct "H" as "[(%R2 & %ε1 & %ε2 & (%Hred & %Hleq2 & %Hub & H)) | Ht]".
       + iLeft.
         iExists R2. iExists ε1. iExists ε2.
+        iSplit; [ done |].
         iSplit; [ iPureIntro; lra | ].
         iSplit; [ done | ].
         iIntros.
@@ -209,9 +226,10 @@ Section exec_ub.
     iPoseProof (least_fixpoint_iter (exec_ub_pre Z1) Φ with "[]") as "H"; last first.
     { by iApply ("H" with "H_ub"). }
     iIntros "!#" ([ε'' [? σ']]). rewrite /exec_ub_pre.
-    iIntros "[ (% & % & % & % & % & H) | [ (% & % & % & % & % & % & H) | [H | H]] ] HZ /=".
+    iIntros "[ (% & % & % & % & % & % & H) | [ (% & % & % & % & % & % & % & H) | [H | H]] ] HZ /=".
     - rewrite least_fixpoint_unfold.
       iLeft. iExists _,_,_.
+      iSplit; [done|].
       iSplit; [done|].
       iSplit.
       { iPureIntro.
@@ -221,6 +239,7 @@ Section exec_ub.
     - rewrite least_fixpoint_unfold.
       iRight; iLeft.
       iExists _,_,_.
+      iSplit; [done|].
       iSplit; [done|].
       iSplit; [done|].
       iSplit.
@@ -233,8 +252,9 @@ Section exec_ub.
       iInduction (get_active σ') as [| l] "IH".
       { rewrite big_orL_nil //. }
       rewrite 2!big_orL_cons.
-      iDestruct "H" as "[(%R2 & %ε1 & %ε2 & (% & % & H)) | Ht]".
+      iDestruct "H" as "[(%R2 & %ε1 & %ε2 & (% & % & % & H)) | Ht]".
       + iLeft. iExists R2. iExists ε1. iExists ε2.
+        iSplit; [done | ].
         iSplit; [iPureIntro; lra | ].
         iSplit; [done | ].
         iIntros.
@@ -295,10 +315,11 @@ Section exec_ub.
                  with "[]") as "H"; last first.
     { iIntros (?). iApply ("H" $! (_, (_, _)) with "Hub [//]"). }
     iIntros "!#" ([ε' [? σ']]). rewrite /exec_ub_pre.
-    iIntros "[(% & % & % & % & % & H) | [ (% & % & % & (%r & %Hr) & % & % & H) | [H | H]]] %Hv'".
+    iIntros "[(% & % & % & % & % & % & H) | [ (% & % & % & % & (%r & %Hr) & % & % & H) | [H | H]]] %Hv'".
     - rewrite least_fixpoint_unfold.
       iLeft. simpl.
       iExists (λ '(e2, σ2), ∃ e2', e2 = K e2' ∧ R2 (e2', σ2)),_,_.
+      iSplit; [iPureIntro; by apply reducible_fill|].
       iSplit; [done|].
       rewrite fill_dmap //=.
       iSplit.
@@ -331,6 +352,7 @@ Section exec_ub.
         rewrite /ε3 HKinv3 //.
       }
       iExists (λ '(e2, σ2), ∃ e2', e2 = K e2' ∧ R2 (e2', σ2)),_,ε3.
+      iSplit; [iPureIntro; by apply reducible_fill|].
       iSplit.
       {
         iPureIntro. exists r. intros (e&σ). rewrite /ε3.
@@ -350,7 +372,7 @@ Section exec_ub.
         - auto.
        }
       + iPureIntro.
-        etrans; [ | apply H0].
+        etrans; [ | apply H1].
         apply Rplus_le_compat_l.
         transitivity (SeriesC (λ '(e,σ), (prim_step (K o) σ' (K e, σ) * ε3 (K e, σ))%R)).
         * etrans; [ | eapply (SeriesC_le_inj _ (λ '(e,σ), (Kinv e ≫= (λ e', Some (e',σ)))))].
@@ -412,9 +434,10 @@ Section exec_ub.
       iInduction (get_active σ') as [| l] "IH".
       { rewrite big_orL_nil //. }
       rewrite 2!big_orL_cons.
-      iDestruct "H" as "[(%R2 & %ε1 & %ε2 & (%Hleq & %Hub & H)) | Ht]".
+      iDestruct "H" as "[(%R2 & %ε1 & %ε2 & (%Hred & %Hleq & %Hub & H)) | Ht]".
       + iLeft.
         iExists _,_,_.
+        iSplit; [iPureIntro; by apply reducible_fill|].
         iSplit; [done|].
         iSplit; [done|].
         iIntros. by iApply ("H" with "[//]").
@@ -477,14 +500,15 @@ Section exec_ub.
 
 
   Lemma exec_ub_prim_step e1 σ1 Z (ε : nonnegreal) :
-    (∃ R (ε1 ε2 : nonnegreal), ⌜ (ε1 + ε2 <= ε)%R ⌝ ∗ ⌜ub_lift (prim_step e1 σ1) R ε1⌝ ∗
+    (∃ R (ε1 ε2 : nonnegreal), ⌜reducible e1 σ1⌝ ∗ ⌜ (ε1 + ε2 <= ε)%R ⌝ ∗ ⌜ub_lift (prim_step e1 σ1) R ε1⌝ ∗
           ∀ ρ2 , ⌜R ρ2⌝ ={∅}=∗ Z ε2 ρ2)
     ⊢ exec_ub e1 σ1 Z ε.
   Proof.
-    iIntros "(% & % & % & % & % & H)".
+    iIntros "(% & % & % & % & % & % & H)".
     rewrite {1}exec_ub_unfold.
     iLeft.
     iExists _,_,_.
+    iSplit; [done|].
     iSplit; [done|].
     iSplit; done.
   Qed.
@@ -492,15 +516,17 @@ Section exec_ub.
 
   Lemma exec_ub_adv_comp e1 σ1 Z (ε : nonnegreal) :
       (∃ R (ε1 : nonnegreal) (ε2 : cfg Λ -> nonnegreal),
+          ⌜reducible e1 σ1⌝ ∗
           ⌜ exists r, forall ρ, (ε2 ρ <= r)%R ⌝ ∗
           ⌜ (ε1 + SeriesC (λ ρ, (prim_step e1 σ1 ρ) * ε2(ρ)) <= ε)%R ⌝ ∗ ⌜ub_lift (prim_step e1 σ1) R ε1⌝ ∗
             ∀ ρ2, ⌜ R ρ2 ⌝ ={∅}=∗ Z (ε2 ρ2) ρ2 )
     ⊢ exec_ub e1 σ1 Z ε.
   Proof.
-    iIntros "(% & % & % & % & % & % & H)".
+    iIntros "(% & % & % & % & % & % & % & H)".
     rewrite {1}exec_ub_unfold.
     iRight; iLeft.
     iExists _,_,_.
+    iSplit; [done|].
     iSplit; [done|].
     iSplit; [done|].
     iSplit; done.
@@ -509,15 +535,17 @@ Section exec_ub.
 
   Lemma exec_ub_adv_comp' e1 σ1 Z (ε : nonnegreal) :
       (∃ R (ε2 : cfg Λ -> nonnegreal),
+          ⌜reducible e1 σ1⌝ ∗
           ⌜ exists r, forall ρ, (ε2 ρ <= r)%R ⌝ ∗
           ⌜ (SeriesC (λ ρ, (prim_step e1 σ1 ρ) * ε2(ρ)) = ε)%R ⌝ ∗ ⌜ub_lift (prim_step e1 σ1) R nnreal_zero⌝ ∗
             ∀ ρ2, ⌜ R ρ2 ⌝ ={∅}=∗ Z (ε2 ρ2) ρ2 )
     ⊢ exec_ub e1 σ1 Z ε.
   Proof.
-    iIntros "(% & % & % & %Hε & % & H)".
+    iIntros "(% & % & % & % & %Hε & % & H)".
     rewrite {1}exec_ub_unfold.
     iRight; iLeft.
     iExists _,nnreal_zero,_.
+    iSplit; [done|].
     iSplit; [done|].
     iSplit.
     { iPureIntro.
@@ -529,12 +557,13 @@ Section exec_ub.
   (* TODO: Maybe allow weakening of the grading *)
   Lemma exec_ub_state_step α e1 σ1 Z (ε ε' : nonnegreal) :
     α ∈ get_active σ1 →
-    (∃ R, ⌜ub_lift (state_step σ1 α) R ε⌝ ∗
+    (∃ R, ⌜reducible e1 σ1⌝ ∗
+          ⌜ub_lift (state_step σ1 α) R ε⌝ ∗
           ∀ σ2 , ⌜R σ2 ⌝ ={∅}=∗ exec_ub e1 σ2 Z ε')
     ⊢ exec_ub e1 σ1 Z (ε + ε').
   Proof.
     iIntros (?) "H".
-    iDestruct "H" as (?) "H".
+    iDestruct "H" as (?) "(% & % & H)".
     rewrite {1}exec_ub_unfold.
     iRight; iRight; iLeft.
     iApply big_orL_elem_of; eauto.
@@ -543,7 +572,7 @@ Section exec_ub.
     iExists ε'.
     iFrame.
     iPureIntro.
-    simpl. lra.
+    by simpl.
   Qed.
 
 
@@ -685,7 +714,6 @@ Definition ub_wp_pre `{!irisGS Λ Σ}
   | Some v => |={E}=> Φ v
   | None => ∀ σ1 ε,
       state_interp σ1 ∗ err_interp ε ={E,∅}=∗
-      ⌜reducible e1 σ1⌝ ∗
       exec_ub e1 σ1 (λ ε2 '(e2, σ2),
         ▷ |={∅,E}=> state_interp σ2 ∗ err_interp ε2 ∗ wp E e2 Φ) ε
 end%I.
@@ -693,10 +721,10 @@ end%I.
 Local Instance wp_pre_contractive `{!irisGS Λ Σ} : Contractive (ub_wp_pre).
 Proof.
   rewrite /ub_wp_pre /= => n wp wp' Hwp E e1 Φ /=.
-  do 8 (f_equiv).
+  do 7 (f_equiv).
   apply least_fixpoint_ne_outer; [|done].
   intros Ψ [ε' [e' σ']]. rewrite /exec_ub_pre.
-  do 14 f_equiv.
+  do 15 f_equiv.
   { f_contractive. do 3 f_equiv. apply Hwp. }
   { do 2 f_equiv. f_contractive. do 3 f_equiv. apply Hwp. }
 Qed.
@@ -732,10 +760,10 @@ Global Instance ub_wp_ne s E e n :
 Proof.
   revert e. induction (lt_wf n) as [n _ IH]=> e Φ Ψ HΦ.
   rewrite !ub_wp_unfold /ub_wp_pre /=.
-  do 8 f_equiv.
+  do 7 f_equiv.
   apply least_fixpoint_ne_outer; [|done].
   intros ? [? []]. rewrite /exec_ub_pre.
-  do 14 f_equiv.
+  do 15 f_equiv.
   { f_contractive. do 3 f_equiv. rewrite IH; [done|lia|].
     intros ?. eapply dist_S, HΦ. }
   { do 2 f_equiv. f_contractive. rewrite IH; [done|lia|].
@@ -752,10 +780,10 @@ Global Instance ub_wp_contractive s E e n :
   Proper (pointwise_relation _ (dist_later n) ==> dist n) (wp (PROP:=iProp Σ) s E e).
 Proof.
   intros He Φ Ψ HΦ. rewrite !ub_wp_unfold /ub_wp_pre He /=.
-  do 7 f_equiv.
+  do 6 f_equiv.
   apply least_fixpoint_ne_outer; [|done].
   intros ? [? []]. rewrite /exec_ub_pre.
-  do 14 f_equiv.
+  do 15 f_equiv.
   { f_contractive. do 6 f_equiv. }
   { do 2 f_equiv. f_contractive. do 6 f_equiv. }
 Qed.
@@ -773,9 +801,7 @@ Proof.
   { iApply ("HΦ" with "[> -]"). by iApply (fupd_mask_mono E1 _). }
   iIntros (σ1 ε) "[Hσ Hε]".
   iMod (fupd_mask_subseteq E1) as "Hclose"; first done.
-  iMod ("H" with "[$]") as "[% H]".
-  iModIntro.
-  iSplit; [done | ].
+  iMod ("H" with "[$]") as "H".
   iApply (exec_ub_mono_pred with "[Hclose HΦ] H").
   iIntros (? [e2 σ2]) "H".
   iModIntro.
@@ -788,7 +814,7 @@ Lemma fupd_ub_wp s E e Φ : (|={E}=> WP e @ s; E {{ Φ }}) ⊢ WP e @ s; E {{ Φ
 Proof.
   rewrite ub_wp_unfold /ub_wp_pre. iIntros "H". destruct (to_val e) as [v|] eqn:?.
   { by iMod "H". }
-  iIntros (σ1 ε) "Hi". iMod "H". by iApply "H".
+   iIntros (σ1 ε) "Hi". iMod "H". by iApply "H".
 Qed.
 Lemma ub_wp_fupd s E e Φ : WP e @ s; E {{ v, |={E}=> Φ v }} ⊢ WP e @ s; E {{ Φ }}.
 Proof. iIntros "H". iApply (ub_wp_strong_mono E with "H"); auto. Qed.
@@ -800,7 +826,7 @@ Proof.
   destruct (to_val e) as [v|] eqn:He.
   { by iDestruct "H" as ">>> $". }
   iIntros (σ1 ε) "[Hσ Hε]". iMod "H".
-  iMod ("H" with "[$]") as "[$ H]".
+  iMod ("H" with "[$]") as "H".
   iModIntro.
   iDestruct (exec_ub_strengthen with "H") as "H".
   iApply (exec_ub_mono_pred with "[] H").
@@ -810,15 +836,15 @@ Proof.
   rewrite !ub_wp_unfold /ub_wp_pre.
   destruct (to_val e2) as [v2|] eqn:He2.
   - iDestruct "H" as ">> $". by iFrame.
-  - iMod ("H" with "[$]") as "(%&H)".
+  - iMod ("H" with "[$]") as "H".
     pose proof (atomic σ e2 σ2 Hstep) as H3.
     case_match.
     + rewrite /is_Some in H3.
       destruct H3.
       simplify_eq.
     + apply not_reducible in H3.
-      done.
-Qed.
+      admit.
+Admitted.
 
 
 Lemma ub_wp_step_fupd s E1 E2 e P Φ :
@@ -827,9 +853,8 @@ Lemma ub_wp_step_fupd s E1 E2 e P Φ :
 Proof.
   rewrite !ub_wp_unfold /ub_wp_pre. iIntros (-> ?) "HR H".
   iIntros (σ1 ε) "[Hσ Hε]". iMod "HR".
-  iMod ("H" with "[$Hσ $Hε]") as "[% H]".
+  iMod ("H" with "[$Hσ $Hε]") as "H".
   iModIntro.
-  iSplit; [done | ].
   iApply (exec_ub_mono_pred with "[HR] H").
   iIntros (? [e2 σ2]) "H".
   iModIntro.
@@ -848,19 +873,16 @@ Proof.
   { apply of_to_val in He as <-. by iApply fupd_ub_wp. }
   rewrite ub_wp_unfold /ub_wp_pre fill_not_val /=; [|done].
   iIntros (σ1 ε) "[Hσ Hε]".
-  iMod ("H" with "[$Hσ $Hε]") as "(%Hs & H)".
+  iMod ("H" with "[$Hσ $Hε]") as "H".
   iModIntro.
-  iSplit.
-  - iPureIntro.
-    apply reducible_fill; auto.
-  - iApply exec_ub_bind; [done |].
-    iApply (exec_ub_mono with "[] [] H").
-    + iPureIntro; lra.
-    + iIntros (? [e2 σ2]) "H".
-      iModIntro.
-      iMod "H" as "(Hσ & Hρ & H)".
-      iModIntro.
-      iFrame "Hσ Hρ". by iApply "IH".
+  iApply exec_ub_bind; [done |].
+  iApply (exec_ub_mono with "[] [] H").
+  - iPureIntro; lra.
+  - iIntros (? [e2 σ2]) "H".
+    iModIntro.
+    iMod "H" as "(Hσ & Hρ & H)".
+    iModIntro.
+    iFrame "Hσ Hρ". by iApply "IH".
 Qed.
 
 (* Lemma wp_bind_inv K `{!LanguageCtx K} s E e Φ : *)

--- a/theories/ub_logic/ub_weakestpre.v
+++ b/theories/ub_logic/ub_weakestpre.v
@@ -551,13 +551,12 @@ Section exec_ub.
   (* TODO: Maybe allow weakening of the grading *)
   Lemma exec_ub_state_step α e1 σ1 Z (ε ε' : nonnegreal) :
     α ∈ get_active σ1 →
-    (∃ R, ⌜reducible e1 σ1⌝ ∗
-          ⌜ub_lift (state_step σ1 α) R ε⌝ ∗
+    (∃ R, ⌜ub_lift (state_step σ1 α) R ε⌝ ∗
           ∀ σ2 , ⌜R σ2 ⌝ ={∅}=∗ exec_ub e1 σ2 Z ε')
     ⊢ exec_ub e1 σ1 Z (ε + ε').
   Proof.
     iIntros (?) "H".
-    iDestruct "H" as (?) "(% & % & H)".
+    iDestruct "H" as (?) "(% & H)".
     rewrite {1}exec_ub_unfold.
     iRight; iRight; iLeft.
     iApply big_orL_elem_of; eauto.
@@ -837,7 +836,12 @@ Proof.
       destruct H3.
       simplify_eq.
     + apply not_reducible in H3.
-      admit.
+      (* so... we could get this back if we did a case match on
+         the exec_ub in H. We would need to exclude the two state step cases somehow. *)
+      rewrite {1}exec_ub_unfold.
+      iDestruct "H" as "[[% [% [% (%Hred&_)]]]|[[% [% [% (%Hred&_)]]]|[H|H]]]".
+      1,2: by destruct H3.
+      (* ??? *)
 Admitted.
 
 

--- a/theories/ub_logic/ub_weakestpre.v
+++ b/theories/ub_logic/ub_weakestpre.v
@@ -63,7 +63,6 @@ Section exec_ub.
       ([∨ list] α ∈ get_active σ1,
       (* We allow an explicit weakening of the grading, but maybe it is not needed *)
         (∃ R (ε1 ε2 : nonnegreal),
-            ⌜reducible e1 σ1⌝ ∗
             ⌜ (ε1 + ε2 <= ε)%R ⌝ ∗
             ⌜ ub_lift (state_step σ1 α) R ε1 ⌝ ∗
               ∀ σ2, ⌜ R σ2 ⌝ ={∅}=∗ Φ (ε2,((e1, σ2))))) ∨
@@ -100,10 +99,9 @@ Section exec_ub.
       iInduction (get_active σ1) as [| l] "IH" forall "H".
       { rewrite big_orL_nil //. }
       rewrite !big_orL_cons.
-      iDestruct "H" as "[(% & % & % & %Hred & %Hsum & %Hlift & HΦ) | H]".
+      iDestruct "H" as "[(% & % & % & %Hsum & %Hlift & HΦ) | H]".
       + iLeft. iExists R2.
         iExists ε1. iExists _.
-        iSplit; [try done|].
         iSplit; [try done|].
         iSplit; [try done|].
         iIntros. iApply "Hwand". by iApply "HΦ".
@@ -139,7 +137,6 @@ Section exec_ub.
             ∀ ρ2, ⌜ R ρ2 ⌝ ={∅}=∗ Z (ε2 ρ2) ρ2 ) ∨
       ([∨ list] α ∈ get_active σ1,
         (∃ R (ε1 ε2 : nonnegreal),
-            ⌜reducible e1 σ1⌝ ∗
             ⌜ (ε1 + ε2 <= ε)%R ⌝ ∗
             ⌜ ub_lift (state_step σ1 α) R ε1 ⌝ ∗
               ∀ σ2, ⌜ R σ2 ⌝ ={∅}=∗ exec_ub e1 σ2 Z ε2 )) ∨
@@ -182,10 +179,9 @@ Section exec_ub.
       iInduction (get_active σ') as [| l] "IH".
       { rewrite big_orL_nil //. }
       rewrite 2!big_orL_cons.
-      iDestruct "H" as "[(%R2 & %ε1 & %ε2 & (%Hred & %Hleq2 & %Hub & H)) | Ht]".
+      iDestruct "H" as "[(%R2 & %ε1 & %ε2 & (%Hleq2 & %Hub & H)) | Ht]".
       + iLeft.
         iExists R2. iExists ε1. iExists ε2.
-        iSplit; [ done |].
         iSplit; [ iPureIntro; lra | ].
         iSplit; [ done | ].
         iIntros.
@@ -252,9 +248,8 @@ Section exec_ub.
       iInduction (get_active σ') as [| l] "IH".
       { rewrite big_orL_nil //. }
       rewrite 2!big_orL_cons.
-      iDestruct "H" as "[(%R2 & %ε1 & %ε2 & (% & % & % & H)) | Ht]".
+      iDestruct "H" as "[(%R2 & %ε1 & %ε2 & (% & % & H)) | Ht]".
       + iLeft. iExists R2. iExists ε1. iExists ε2.
-        iSplit; [done | ].
         iSplit; [iPureIntro; lra | ].
         iSplit; [done | ].
         iIntros.
@@ -434,10 +429,9 @@ Section exec_ub.
       iInduction (get_active σ') as [| l] "IH".
       { rewrite big_orL_nil //. }
       rewrite 2!big_orL_cons.
-      iDestruct "H" as "[(%R2 & %ε1 & %ε2 & (%Hred & %Hleq & %Hub & H)) | Ht]".
+      iDestruct "H" as "[(%R2 & %ε1 & %ε2 & (%Hleq & %Hub & H)) | Ht]".
       + iLeft.
         iExists _,_,_.
-        iSplit; [iPureIntro; by apply reducible_fill|].
         iSplit; [done|].
         iSplit; [done|].
         iIntros. by iApply ("H" with "[//]").


### PR DESCRIPTION
- [x] add tapes to the ghost state (already done!)
- [x] add wp rules for tapes at `rand` (already done!)
- [x] add a presampling rule (`wp_presample`)
    - [x] lifting lemma for state steps 
- [x] add an advanced composition rule for tapes
    - [x] update exec modality
    - [x] remaining admitted: `exec_ub_bind`
    - [x] remaining admitted: adequacy  
- [x] implement analogue of `wp_couple_rand_adv_comp` (ie. `wp_presample_adv_comp`) on tapes
   - [x] (FIXME) see if ``classic_proof_irrel.PIT.EqdepTheory.inj_pair2`` is necessary 
   - [x] (FIXME) see if ``E = ∅`` is necessary  
   - finish `wp_couple_rand_adv_comp`?
   - [x] cleanup 
- [x] port the planner rule to use tapes
    - apply Hei's proof as adequacy for almost-sure wp? 
    - (FIXME) see if there's a more ergonomic way to remove the hypothesis which only get threaded through
- [ ] prove `ec_spend_1` as WP (Hei is working on this)
    - [ ] update planner rule proof
    - [ ] cleanup
- [ ] reimplement some rejection sampler examples using the planner rule (different PR) 
    - other examples from that paper? 
- [x] cleanup/remove notes
- implement `wp_couple_rand_adv_comp` as sequence of state steps w/ fresh tape? 