### PR TITLE
Approximate rejection sampler examples

### DIFF
--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -138,9 +138,15 @@ Section finite.
   Qed.
 
   Lemma fin2_nat_bool (x : fin 2) : (fin_to_nat x =? 1)%nat = (fin_to_bool x).
-  Proof. Admitted.
-
-
+  Proof.
+    destruct (fin2_enum x) as [H|H]; rewrite H; simpl.
+    - replace 0%nat with (@fin_to_nat 2 (0%fin)) in H by auto.
+      apply fin_to_nat_inj in H.
+      by rewrite H /=.
+    - replace 1%nat with (@fin_to_nat 2 (1%fin)) in H by auto.
+      apply fin_to_nat_inj in H.
+      by rewrite H /=.
+  Qed.
 
 End finite.
 
@@ -867,13 +873,8 @@ Section higherorder.
   Lemma credit_spend_1 : €nnreal_one -∗ ▷ False.
   Proof. Admitted.
 
-
   Definition scale_unless (𝜀 𝜀1 : nonnegreal) (Θ : val -> bool) : val -> nonnegreal
     := (fun z => if (Θ z) then nnreal_zero else (nnreal_div 𝜀1 𝜀)%NNR).
-
-  Lemma scale_unless_cmp a b 𝜀 v Θ : (scale_unless b (scale_unless a 𝜀 Θ #v) Θ #v) = (scale_unless (a*b)%NNR 𝜀 Θ #v).
-  Proof. Admitted.
-
 
   Definition sampling_scheme_spec (e : expr) 𝜀factor 𝜀final E (Ψ : val -> bool) (Θ : val -> bool) : Prop
     := {{{ True }}}

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -378,17 +378,21 @@ Section basic.
         wp_apply ("IH" with "Hcr HΦ").
   Qed.
 
-  Lemma error_limit (r : nonnegreal) : (r < 1) -> forall 𝜀 : nonnegreal, exists n : nat, r ^ (S n) < 𝜀.
+  Lemma error_limit (r : nonnegreal) : (r < 1) -> forall 𝜀 : posreal, exists n : nat, r ^ (S n) < 𝜀.
   Proof.
     intros Hr 𝜀.
     assert (Har : Rabs r < 1).
     { destruct r as [rv Hrv]. simpl. rewrite Rabs_pos_eq; auto. }
     pose Lm := Lim_seq.is_lim_seq_geom r Har.
-    unfold Lim_seq.is_lim_seq in Lm.
-    unfold Hierarchy.eventually in Lm.
-    pose Q := Lim_seq.filterlim_le _ _ _ _ _ Lm.
-    (* how to get the regular defeinition of a limit from this??? *)
-  Admitted.
+    apply Lim_seq.is_lim_seq_spec in Lm.
+    simpl in Lm.
+    specialize Lm with 𝜀.
+    rewrite /Hierarchy.eventually in Lm.
+    destruct Lm as [n Hn]; exists n; specialize Hn with (S n).
+    replace (Rabs (r ^ S n - 0)) with (r ^ S n) in Hn; last first.
+    { rewrite Rabs_right; rewrite Rminus_0_r; [done | apply Rle_ge, pow_le; by destruct r ]. }
+    apply Hn; lia.
+  Qed.
 
 
   (** PROBLEM 4: show that any positive error 𝜀 suffices to make the unbounded sampler terminate inbounds *)

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -1141,7 +1141,8 @@ Section integer_walk.
     intros. rewrite /IC /=.
     apply Rmax_left.
     apply Rcomplements.Rmult_le_0_l; [apply cond_nonneg|].
-    (* true... but how do I do this? *)
+    rewrite /IZR.
+    (* true but annoying *)
   Admitted.
 
   Lemma IC_ge_L εᵢ : forall (z : Z), (z >= (L εᵢ))%Z -> (nonneg (IC εᵢ z) >= 1)%R.
@@ -1149,7 +1150,7 @@ Section integer_walk.
     intros. rewrite /IC /=.
     rewrite Rmax_right; last first.
     { apply Rmult_le_pos; [apply cond_nonneg|].
-      (* FIXME: *)
+      (* FIXME: IZR of pos is pos *)
       admit.
     }
     rewrite /L in H0.
@@ -1159,7 +1160,8 @@ Section integer_walk.
   Lemma IC_mean εᵢ : forall (z : Z), (z >= 0)%Z ->
                        (nonneg (IC εᵢ (z - 1)%Z) + nonneg (IC εᵢ (z + 1)%Z) = 2 * nonneg (IC εᵢ z))%R.
   Proof.
-    (* It's linear for z ∈ [-1, ∞) *)
+    (* It's linear for z ∈ [-1, ∞)
+       this is unused atm *)
   Admitted.
 
   (* Credit to amplify within the sequence *)
@@ -1174,7 +1176,7 @@ Section integer_walk.
 
   Program Definition kwf_L εᵢ (Hεᵢ : (nonneg εᵢ < 1)%R) : kwf 2 (L εᵢ) := mk_kwf _ _ _ _.
   Next Obligation. intros; lia. Qed.
-  Next Obligation. intros. rewrite /L. Admitted. (* doable *)
+  Next Obligation. intros. rewrite /L. Admitted. (* doable, unused atm though *)
 
   Program Definition Δε (εᵢ : nonnegreal) (εₐ : posreal) kwf : nonnegreal :=
     mknonnegreal (εAmp 2 (L εᵢ) εₐ kwf - εₐ)%R _.
@@ -1215,7 +1217,24 @@ Section integer_walk.
     wp_pures.
     wp_bind (rand _)%E.
 
-    (* I think we need a special case for z < 0? *)
+    (* I think we need a special case for z < 0?
+       IC (-3) = 0
+       IC (-2) = 0
+       IC (-1) = 0
+       IC (0)  =  εᵢ
+       IC (0)  = 2εᵢ
+       IC (0)  = 3εᵢ
+
+      The mean proerty does _not_ hold at z = -1!
+
+      My intuition is that this should be fixable by strengthening the spec, though, since we only ever
+      get to z = -1 once the checker has already passed and the program has already terminated.
+
+      Maybe I move the progress measure backwards to hit 0 at -2 or -3? If I do this, I can change it to
+      quantify over nat instead of Z... the same problem will arise at the left endpoint, but that should be
+      excluded by virtue of the (S p) in the amp spec.
+
+     *)
     wp_apply (wp_couple_rand_adv_comp1 _ _ _ _
                 ((IC εᵢ (S p)) + (AC εᵢ εₐ (L εᵢ - S p) (I_obligation_1 εᵢ (S p)) kwf))%NNR
                 (integer_walk_distr εᵢ εₐ (S p) kwf) with "[HcrAC HcrIC]").
@@ -1351,6 +1370,18 @@ Section integer_walk.
           Check (IC_ge_L εᵢ (S (L εᵢ)) Hk).
           (* We have an amount of credit greater than or equal to 1, so we conclude *)
   Admitted.
+
+
+  (* TODO: a spec which actually gives the resources for the higher order thing for any € ε and (l ↦ 0).
+      - Split the credit in half
+        - ((AX εᵢ εₐ kwf) p) is 0 for even relatively small values of p (depends on ε), so this is free.
+        - IC is quantified over εᵢ, and AC goes to 0 in the limit of p, so this should exist.
+          + We need p <= L, could this be a culprit for not generalizing to unbiased coins?
+            Unfold the definitions of (εR L) to see.
+   *)
+  Lemma wp_checker_init
+
+
 End integer_walk.
 
 

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -381,40 +381,19 @@ Section basic.
     { intros. by rewrite Rmult_assoc. }
     rewrite X -Rinv_r_sym; last (apply not_0_INR; lia).
     rewrite Rmult_1_l.
-
-
-   (*
-    (* turn it into a sum over the naturals so we can use all the familiar SeriesC lemmas *)
-    rewrite SeriesC_fin_to_nat.
-
-    (* somehow we want to _reindex_ this series *)
-    rewrite (series_incr_N_zero _ (S n')); last first.
-    { intros.
-      rewrite f_lift_fin_nat_ltN; first lia.
-      intros Hyp.
-      rewrite bool_decide_eq_true_2; auto.
-      rewrite fin_to_nat_to_fin.
-      lia.
-    }*)
-
-
-
-    (* now the sum is constant, but we run into the same kind of reindexing nonsense as above.
-       prove that first. *)
-
-    (* or now that I think about it again, I think that since I want to eventually use SeriesC_finite_mass,
-       I might want to keep this as a sum over fin?
-
-        I'll eventually have to do the same series comparison dance as before... does that also work on fin?
-     *)
     rewrite reindex_fin_series SeriesC_finite_mass fin_card.
     rewrite /err_factor.
-    (* provable *)
-  Admitted.
-
-
-
-
+    remember (S m' - S n')%nat as D.
+    remember (S m') as M.
+    rewrite /= Rinv_mult Rinv_inv.
+    rewrite -Rmult_assoc -Rmult_assoc Rmult_comm.
+    apply Rmult_eq_compat_l.
+    rewrite Rmult_comm -Rmult_assoc Rinv_l.
+    - by rewrite Rmult_1_l.
+    - rewrite HeqD HeqM.
+      apply not_0_INR.
+      lia.
+  Qed.
 
 
 

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -220,71 +220,6 @@ Section basic.
     symmetry; apply SuccNat2Pos.pred_id.
   Qed.
 
-  Lemma encode_inv_nat_fin_total (n N: nat) (H : (n < N)%nat) : (@encode_inv_nat (fin N) _ _ n) = Some (nat_to_fin H).
-  Proof.
-    (* assert (H' : (n < card (fin N))%nat) by (rewrite fin_card; lia).
-    destruct (encode_inv_decode n H') as [x [-> Hx]]; f_equal.
-    rewrite /encode_nat in Hx.   *)
-
-    rewrite -encode_inv_encode_nat.
-    f_equal.
-    rewrite /encode_nat.
-    rewrite /encode /nat_countable /finite_countable.
-    rewrite -Pos.of_nat_succ SuccNat2Pos.pred_id.
-    replace (list_find (eq (nat_to_fin H)) (enum (fin N))) with (Some (n, nat_to_fin H)); first by simpl.
-
-
-    (* the fact that I'm using nat_to_fin H has being... extremely annoying. But I'm not sure
-        if there's a better option.
-
-
-
-     *)
-    (* Check fin_to_nat_to_fin.
-    Check nat_to_fin_to_nat. *)
-
-    rewrite /enum; simpl.
-    symmetry; apply list_find_Some; split; last split.
-    - induction n as [|n' IH].
-      + intros. simpl. destruct N; [lia | done].
-      + (* lost, is this the right induction? *)
-
-        (* can use to turn (nat_to_fin (_ < (S N'))) into (nat_to_fin (_ < N'))
-           Check Fin.of_nat_ext.
-        *)
-        admit.
-    - done.
-    - admit.
-  Admitted.
-
-
-  Lemma encode_inv_nat_fin_undef (n N: nat) (H : not (n < N)%nat) : (@encode_inv_nat (fin N) _ _ n) = None.
-  Proof.
-    apply encode_inv_decode_ge.
-    rewrite fin_card.
-    lia.
-  Qed.
-
-  Lemma SeriesC_fin_to_nat (N : nat) (f : fin N -> R) :
-    SeriesC (fun s : fin N => f s) = SeriesC (fun n : nat => (f_lift_fin_nat N 0 f) n).
-  Proof.
-    (* can't use SeriesC_ext since the two series have different types
-       can we use series_ext on the underlying countable sum? *)
-    rewrite /SeriesC.
-    apply Series_ext; intros n.
-    rewrite /countable_sum.
-    rewrite encode_inv_nat_nat_total.
-    remember (n <? N)%nat as K; destruct K.
-    - symmetry in HeqK; apply Nat.ltb_lt in HeqK.
-      rewrite encode_inv_nat_fin_total.
-      simpl. by rewrite f_lift_fin_nat_ltN.
-    - rewrite encode_inv_nat_fin_undef; last (apply Nat.ltb_nlt; by symmetry).
-      simpl.
-      rewrite f_lift_fin_nat_geN; last (apply Nat.ltb_nlt; by symmetry).
-      done.
-  Qed.
-
-
 
   Lemma series_incr_N_zero f N :
     (forall m : nat, (m < N)%nat -> f m = 0) -> SeriesC (fun n : nat => f n) = SeriesC (fun n : nat => f (N + n)%nat).
@@ -347,8 +282,6 @@ Section basic.
       (@Hierarchy.sum_n_m Hierarchy.R_AbelianGroup (@countable_sum (Fin.t M) (@fin_dec M) (@finite_countable (Fin.t M) (@fin_dec M) (fin_finite M)) (λ x : fin M, if (@bool_decide (x < N)%nat (@decide_rel nat nat lt Nat.lt_dec (@fin_to_nat M x) N)) then nnreal_zero else K)) N (n + N)%nat);
       last first.
     { admit. }*)
-
-
 
     induction n as [| n' IH].
     - simpl.

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -540,12 +540,12 @@ Qed.
 
 
   (** PROBLEM 4: show that any positive error 𝜀 suffices to make the unbounded sampler terminate inbounds *)
-  Theorem ubdd_cf_safety (n' m' : nat) (Hnm : (S n' < S m')%nat) E : forall 𝜀,
-    ⊢ {{{ €𝜀 ∗ ⌜𝜀 > 0 ⌝  }}} ubdd_rejection_sampler n' m' #()@ E {{{ v, RET v ; ⌜exists v' : nat, v = SOMEV #v' /\ (v' < S n')%nat⌝ }}}.
+  Theorem ubdd_cf_safety (n' m' : nat) (Hnm : (S n' < S m')%nat) E : forall 𝜀 : nonnegreal,
+    ⊢ {{{ €𝜀 ∗ ⌜0 < 𝜀 ⌝  }}} ubdd_rejection_sampler n' m' #()@ E {{{ v, RET v ; ⌜exists v' : nat, v = SOMEV #v' /\ (v' < S n')%nat⌝ }}}.
   Proof.
     iIntros (𝜀 Φ) "!> (Hcr&%Hcrpos) HΦ".
-    assert (Hef: (err_factor (S n') (S m')) < 1).
-    destruct (error_limit (err_factor (S n') (S m')) Hef 𝜀) as [d].
+    assert (Hef: (err_factor (S n') (S m')) < 1) by (apply err_factor_lt1; lia).
+    destruct (error_limit (err_factor (S n') (S m')) Hef (mkposreal 𝜀 Hcrpos)) as [d].
     iApply ((ubdd_approx_safe _ _ d Hnm) with "[Hcr] [HΦ]"); auto.
     iApply ec_weaken; last iAssumption.
     rewrite /bdd_cf_error.

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -3,7 +3,7 @@ From clutch.ub_logic Require Export ub_clutch.
 
 Set Default Proof Using "Type*".
 
-Section proofs.
+Section basic.
   Local Open Scope R.
   Context `{!clutchGS Σ}.
 
@@ -99,7 +99,11 @@ Section proofs.
   (* this lemma is for proofs which iterate up until the last sample
      ie, a rejection sampler to exclude the final recursive step *)
   Lemma bdd_cd_error_penultimate n m : bdd_cf_error n m 1 = err_factor n m.
-  Proof. rewrite /bdd_cf_error /nnreal_nat_exp. (* nnreal: _ * 1 = _ *) Admitted.
+  Proof. rewrite /bdd_cf_error /nnreal_nat_exp. (* nnreal: _ * 1 = _ *)
+
+         Locate nnreal_one.
+
+  Admitted.
 
   (* distribution of error mass 𝜀₁ for a given sample:
       - zero error given to cases which are inbounds
@@ -316,7 +320,7 @@ Section proofs.
   Theorem ubdd_cf_safety (n' m' : nat) (Hnm : (S n' < S m')%nat) E : forall 𝜀,
     ⊢ {{{ €𝜀 ∗ ⌜𝜀 > 0 ⌝  }}} ubdd_rejection_sampler n' m' #()@ E {{{ v, RET v ; ⌜exists v' : nat, v = SOMEV #v' /\ (v' < S n')%nat⌝ }}}.
   Proof.
-    iIntros (𝜀 Φ) " !> (Hcr&%Hcrpos) HΦ".
+    iIntros (𝜀 Φ) "!> (Hcr&%Hcrpos) HΦ".
     destruct (nnreal_nat_exp_limit (err_factor (S n') (S m')) 𝜀) as [d].
     - apply err_factor_lt1; lia.
     - iApply (ubdd_approx_safe with "[Hcr] [HΦ]"); auto.
@@ -328,11 +332,58 @@ Section proofs.
 
 
   (* PROBLEM ??: If error credits can rule out nontermination we could show that the unbounded
-     rejection sampler doesn't terminate with probability zero (in the UB logic)  *)
+     rejection sampler doesn't terminate with probability zero (in the UB logic)
+
+        total wp in iris
+         - no laters required
+
+        finite later credit budget or 𝜔
+         - not yet
+
+        higher order version:
+          - sampler
+          -  f: () -> (A, test)
+          -  {{{ € 𝜖 }}} f {{{ true  }}}
+   *)
 
   (* PROBLEM ??: We should be able to prove:
         - the unbounded sampler is equivalent to the bounded sampler with a given error
         - the bounded sampler is equivalent to a single sample with a given error
-      in the approximate relational logic. *)
+      in the approximate relational logic.
 
-End proofs.
+      - distinct
+      - hard to do lifting in Iris
+      - encode UB judgements as relational program with no spec
+
+      Refinement up to error for bdd and ubdd
+
+      higher order spec fo
+
+      input:
+        with € \varpesilon, g and f are equal with err ... (refinemenet)
+        then if we use one for the programs in a rejection sampler
+
+        one does a pure sample, the other one is used in a rejection sampler
+   *)
+
+End basic.
+
+
+Section termination.
+  Local Open Scope R.
+  Context `{!clutchGS Σ}.
+
+
+
+End termination.
+
+
+
+
+Section higherorder.
+  Local Open Scope R.
+  Context `{!clutchGS Σ}.
+
+  Definition generic_sampler : Set = False.
+
+End higherorder.

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -1,10 +1,8 @@
-From clutch.app_rel_logic Require Export app_weakestpre primitive_laws.
 From clutch.ub_logic Require Export ub_clutch.
 From Coquelicot Require Import Series.
 Require Import Lra.
 
 Set Default Proof Using "Type*".
-
 
 Section finite.
   (* generalization of Coq.Logic.FinFun: lift functions over fin to functions over nat *)
@@ -61,10 +59,6 @@ Section finite.
     rewrite -encode_inv_encode_nat; f_equal.
 
     (* Set Printing Coercions. *)
-
-    Check nat_to_fin_to_nat.
-
-
     (* even though this looks promising, I think it's going nowhere because the a is under an existential.
     assert (H' : (n < card (fin N))%nat).
     { by rewrite fin_card. }
@@ -246,6 +240,8 @@ Section finSeries.
         destruct (encode_inv_nat x) as [t|]; by simpl. }
 
       (* now the two series are both constant zero, we cam simplify *)
+      admit.
+      (*
       rewrite Hierarchy.sum_n_const Rmult_0_r.
       rewrite /countable_sum.
 
@@ -255,6 +251,7 @@ Section finSeries.
       rewrite bool_decide_false; try lia.
       rewrite Hierarchy.plus_zero_l.
       done.
+       *)
     - simpl.
       rewrite Hierarchy.sum_Sn.
       rewrite Hierarchy.sum_Sn.
@@ -277,7 +274,7 @@ Section finSeries.
         rewrite encode_inv_nat_fin_undef; last lia.
         rewrite encode_inv_nat_fin_undef; last auto.
         done.
-  Qed.
+  Admitted.
 
   (* almost certainly this is the better way to prove the above *)
   Lemma SeriesC_finite_foldr `{Finite A} (f : A → R) :
@@ -838,8 +835,9 @@ Section basic.
     destruct Lm as [n Hn]; exists n; specialize Hn with (S n).
     replace (Rabs (r ^ S n - 0)) with (r ^ S n) in Hn; last first.
     { rewrite Rabs_right; rewrite Rminus_0_r; [done | apply Rle_ge, pow_le; by destruct r ]. }
-    apply Hn; lia.
-  Qed.
+    admit.
+    (* apply Hn; lia. *)
+  Admitted.
 
 
   (** PROBLEM 4: show that any positive error 𝜀 suffices to make the unbounded sampler terminate inbounds *)
@@ -1081,13 +1079,14 @@ Section higherorder.
           rewrite /generic_geometric_error /=.
           rewrite /generic_geometric_error /= in H𝜀'.
           assert (0 <= nonneg r) by (destruct r; auto).
-          apply (Rmult_le_reg_l r); first by lra.
-          lra.
+          admit.
+          (* apply (Rmult_le_reg_l r); first by lra.
+          lra. *)
         * do 2 wp_pure.
           iClear "#".
           replace #((S (S depth')) - 1) with #(S depth'); [| do 2 f_equal; lia].
           iApply "IH".
-  Qed.
+  Admitted.
 
 End higherorder.
 
@@ -1140,6 +1139,8 @@ Section higherorder_rand.
     rewrite /rand_𝜀2 /scale_unless.
     rewrite /rand_check_accepts.
     (* this is only here to let me rewrite under the series body. A more general setoid tactic might do this? *)
+    admit.
+    (*
     replace
       (@SeriesC (Fin.t (S m')) (@fin_dec (S m')) (@finite_countable (Fin.t (S m')) (@fin_dec (S m')) (fin_finite (S m')))
        (fun x : Fin.t (S m') =>
@@ -1176,7 +1177,8 @@ Section higherorder_rand.
     - rewrite HeqD HeqM.
       apply not_0_INR.
       lia.
-  Qed.
+     *)
+  Admitted.
 
 
 
@@ -1306,10 +1308,13 @@ Section higherorder_rand.
         iSplit.
         * (* credit is amplified *)
           iPureIntro.
+          admit.
+          (*
           replace (nonneg (rand_𝜀2 _ _ _ _)) with (𝜀 * / (err_factor (S n') (S m'))).
           { rewrite Rmult_assoc -Rinv_l_sym; [lra | apply err_factor_nz_R; lia ]. }
           { rewrite  /rand_𝜀2 /scale_unless /rand_check_accepts.
             replace (s <=? n')%Z with false by lia. simpl; lra. }
+           *)
         * (* sampler rejects *)
           wp_pures; iModIntro; iPureIntro.
           do 2 f_equal; apply bool_decide_false; lia.
@@ -1348,7 +1353,7 @@ Section higherorder_rand.
     Unshelve.
     { apply Φ. }
     { rewrite Nat2Z.id; apply TCEq_refl. }
-  Qed.
+  Admitted.
 
 End higherorder_rand.
 
@@ -1416,7 +1421,8 @@ Section higherorder_flip2.
       + destruct 𝜀h as [𝜀hv H𝜀hvpos]. rewrite /bound /=. lra.
     - (* series mean *)
       rewrite SeriesC_finite_foldr /enum /fin_finite /fin_enum /𝜀2_flip1 /=.
-      lra.
+      admit.
+      (* lra. *)
     - (* continutation *)
       iNext. iIntros (n) "Hcr".
       iApply ("HΦ" $! (fin_to_nat n)); iSplitR.
@@ -1434,7 +1440,7 @@ Section higherorder_flip2.
       Unshelve.
       { apply Φ. }
       { apply TCEq_refl. }
-  Qed.
+  Admitted.
 
 
   Lemma flip2_sampling_scheme_spec E :

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -319,8 +319,6 @@ Section basic.
   Admitted.
 
 
-
-
   (* mean of error distribution is preserved *)
   Lemma sample_err_mean n' m' (Hnm : (n' < m')%nat) 𝜀₁ :
     SeriesC (λ s : fin (S m'), (1 / S m') * bdd_cf_sampling_error (S n') (S m') 𝜀₁ s) = 𝜀₁.
@@ -338,23 +336,17 @@ Section basic.
     rewrite SeriesC_fin_to_nat.
 
     (* somehow we want to _reindex_ this series *)
+    rewrite (series_incr_N_zero _ (S n')); last first.
+    { intros.
+      rewrite f_lift_fin_nat_ltN; first lia.
+      intros Hyp.
+      rewrite bool_decide_eq_true_2; auto.
+      rewrite fin_to_nat_to_fin.
+      lia.
+    }
 
-
-    (* finite sum to sum_n_m? *)
-    (* finite sum to nat sum? *)
-
-    Check Hierarchy.sum_n_m _ 0 5.
-
-
-    (* rewrite to be a difference? *)
-    replace (S m') with (S n' + (S m' - S n'))%nat; last lia.
-    remember (S m' - S n')%nat as 𝛥.
-    induction 𝛥 as [| 𝛥' IH].
-    - (* extensionally equal to 0 *)
-      Fail rewrite <- (SeriesC_ext (fun x : fin (S n' + 0) => nnreal_zero)).
-      admit.
-    - admit.
-
+    (* now the sum is constant, but we run into the same kind of reindexing nonsense as above.
+       prove that first. *)
 
   Admitted.
 
@@ -376,67 +368,6 @@ Proof.
     apply Series_singleton.
 Qed.
 
-
-
-
-
-
-
-    (* we want something pretty close to SeriesC_leq *)
-
-
-
-
-    (* replace (s <? S n') with (bool_decide (s < S n')%nat).
-    (* for some reason it doesn't unify unless I explicitly give it the body? awkward *)
-    Set Printing Coercions.
-    rewrite /SeriesC /countable_sum. rewrite /Series.Series.
-
-
-
-    remember
-      (fun s : fin (S m') => 1 / INR (S m') * nonneg (if (fin_to_nat s <? S n')%nat then nnreal_zero else nnreal_div 𝜀₁ (err_factor (S n') (S m'))))
-      as Body.
-    rewrite (SeriesC_split_pred Body (fun s => (s <? S n')%nat)).
-    - Check SeriesC_finite_bound.
-       unfold SeriesC.
-       unfold Series.Series.
-
-
-      (* simplify the first series
-      replace (SeriesC (λ a : fin (S m'), if (a <? S n')%nat then Body a else 0))
-        with (SeriesC (λ a : fin (S m'), 0)); last first.
-      { apply SeriesC_ext.
-        intros s.
-        remember (s <? S n')%nat as HCond.
-        destruct HCond; try done.
-        rewrite HeqBody; rewrite <- HeqHCond.
-        replace (nonneg nnreal_zero) with 0 by auto.
-        by rewrite Rmult_0_r. }
-      (* simplify the second series *)
-      pose K := (1 / S m' * nnreal_div 𝜀₁ (err_factor (S n') (S m'))).
-      replace (SeriesC (λ a : fin (S m'), if (a <? S n')%nat then 0 else Body a)) with (nonneg 𝜀₁); last first.
-      {  apply SeriesC_ext.
-         intros s.
-         remember (s <? S n')%nat as HCond.
-         destruct HCond.
-
-      }
-
-      (* lol wait, this is the same problem *)
-
-    -
-    -
-
-
-
-
-    /err_factor.
-    (* split the sum into the elements less than n and those greater *)
-    (* sum of constant zero is zero *)
-    (* after simplification, the other sum has m-n elements at constant (𝜀₁/m-n) *)
-
-    *)*)
 
 
 

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -179,12 +179,53 @@ Section basic.
   Lemma sample_err_mean n' m' 𝜀₁ :
     SeriesC (λ s : fin (S m'), (1 / S m') * bdd_cf_sampling_error (S n') (S m') 𝜀₁ s) = 𝜀₁.
   Proof.
-    remember (S n') as n.
-    remember (S m') as m.
-    rewrite /bdd_cf_sampling_error /err_factor.
+    (* remember (S n') as n.
+    remember (S m') as m. *)
+    rewrite /bdd_cf_sampling_error.
+    (* for some reason it doesn't unify unless I explicitly give it the body? awkward *)
+    remember
+      (fun s : fin (S m') => 1 / INR (S m') * nonneg (if (fin_to_nat s <? S n')%nat then nnreal_zero else nnreal_div 𝜀₁ (err_factor (S n') (S m'))))
+      as Body.
+    rewrite (SeriesC_split_pred Body (fun s => (s <? S n')%nat)).
+    -  Check SeriesC_finite_bound.
+       unfold SeriesC.
+       unfold Series.Series.
+
+
+      (* simplify the first series
+      replace (SeriesC (λ a : fin (S m'), if (a <? S n')%nat then Body a else 0))
+        with (SeriesC (λ a : fin (S m'), 0)); last first.
+      { apply SeriesC_ext.
+        intros s.
+        remember (s <? S n')%nat as HCond.
+        destruct HCond; try done.
+        rewrite HeqBody; rewrite <- HeqHCond.
+        replace (nonneg nnreal_zero) with 0 by auto.
+        by rewrite Rmult_0_r. }
+      (* simplify the second series *)
+      pose K := (1 / S m' * nnreal_div 𝜀₁ (err_factor (S n') (S m'))).
+      replace (SeriesC (λ a : fin (S m'), if (a <? S n')%nat then 0 else Body a)) with (nonneg 𝜀₁); last first.
+      {  apply SeriesC_ext.
+         intros s.
+         remember (s <? S n')%nat as HCond.
+         destruct HCond.
+
+      }
+
+      (* lol wait, this is the same problem *)
+
+    -
+    -
+
+
+
+
+    /err_factor.
     (* split the sum into the elements less than n and those greater *)
     (* sum of constant zero is zero *)
     (* after simplification, the other sum has m-n elements at constant (𝜀₁/m-n) *)
+
+    *)
   Admitted.
 
 

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -886,11 +886,24 @@ Section higherorder.
             (∀ v : val, {{{ ⌜Ψ v = true⌝ }}} ((Val checker) v) @ E {{{ b, RET #b; ⌜b = Θ v⌝ }}}) ∗
             (* 𝜀 credit suffices to force checker to pass, on any possible sampled values *)
             (∀ v : val, {{{ €𝜀final }}} ((Val sampler) v) @ E {{{ v', RET v'; ⌜Ψ v' = true ⌝ ∗ ⌜Θ v' = true ⌝ }}}) ∗
-            (* get weird typeclass errors when including this...
-                {{{ True }}} ((Val checker) v) @ E {{{ v', RET v'; ⌜v' = true ⌝ }}} *)
             (* we can always just get _some_ value out of the sampler if we want *)
             ({{{ True }}} (Val sampler) #() @ E {{{ v, RET v; ⌜Ψ v = true ⌝ }}})
        }}}.
+
+  (* version of the sampling scheme spec which removes the need for Θ, and expresses Ψ as a prop *)
+  Definition sampling_scheme_spec_aggressive_ho (sampler checker : val) 𝜀factor 𝜀final E (Ψ : val -> Prop) : iProp Σ
+    := (* amplification during the rejection check  *)
+       ((∀ 𝜀,  {{{ € 𝜀 }}}
+                ((Val sampler) #())%E @ E
+              {{{ v, RET v; ⌜Ψ v⌝ ∗ ((WP ((Val checker) v) @ E {{ λ v', ⌜v' = #true ⌝ }}) ∨
+                                       (∃ 𝜀', € 𝜀' ∗ ⌜𝜀 <= 𝜀' * 𝜀factor ⌝ ∗ (WP ((Val checker) v) {{ λ v', ⌜v' = #false⌝ }}))) }}}) ∗
+        (* final sample can be forced to accept *)
+        (∀ v : val,
+              {{{ € 𝜀final }}}
+                ((Val sampler) v) @ E
+              {{{ v', RET v'; ⌜Ψ v'⌝ ∗ (WP ((Val checker) v') {{ λ v', ⌜v' = #true ⌝ }}) }}}) ∗
+        (* we can always just get _some_ value out of the sampler if we want *)
+        ({{{ True }}} (Val sampler) #() @ E {{{ v, RET v; ⌜Ψ v⌝ }}}))%I.
 
   (* higher order rejection sampler *)
   Definition ho_bdd_rejection_sampler :=
@@ -1002,6 +1015,79 @@ Section higherorder.
         { do 2 f_equal. rewrite Nat2Z.inj_succ. lia. }
         iApply "IH".
   Qed.
+
+  (* for some reason wp_wand doesn't work-- I guess something like this would be provale though?
+     maybe I can try lifting it myself *)
+  Lemma ub_wp_wand s E e Φ Ψ : WP e @ s; E {{ Φ }} -∗ (∀ v, Φ v -∗ Ψ v) -∗ WP e @ s; E {{ Ψ }}.
+  Proof. Admitted.
+
+  (* prove the bounded rejection sampler always ends in SOME using only the higher order spec *)
+  Definition aggressive_ho_bdd_approx_safe (sampler checker : val) (r 𝜀final : nonnegreal) (depth : nat) Ψ E :
+    (not (eq (nonneg r) 0)) ->
+    (not (eq (nonneg 𝜀final) 0)) ->
+    r < 1 ->
+    𝜀final < 1 ->
+    sampling_scheme_spec_aggressive_ho sampler checker r 𝜀final E Ψ -∗
+    € (generic_geometric_error r 𝜀final depth) -∗
+    (WP (ho_bdd_rejection_sampler #(S depth) ((sampler, checker))%V) @ E {{ fun v => ∃ v', ⌜ v = SOMEV v' ⌝}})%I.
+  Proof.
+    (* initial setup *)
+    rewrite /sampling_scheme_spec_aggressive_ho.
+    iIntros (Hr_pos H𝜀final_pos Hr H𝜀final) "(#Hamplify&#Haccept&#Hsample) Hcr".
+    rewrite /ho_bdd_rejection_sampler.
+    do 13 wp_pure.
+
+    iInduction depth as [|depth' Hdepth'] "IH".
+    - (* base case: spend to eliminate the bad sample *)
+
+      (* step the sampler*)
+      wp_pures; wp_bind (sampler #())%E.
+      wp_apply ("Haccept" with "[Hcr]").
+      { iApply (ec_weaken with "Hcr"). rewrite /generic_geometric_error /=; lra. }
+
+      (* step the checker using the new WP *)
+      iIntros (next_sample) "(#Hnext_sample&Hcheck_accept)".
+      (* for some reason this is unhappy, but the proof is basically done now *)
+      wp_pures.
+      wp_bind (checker next_sample)%E.
+      Fail iApply (wp_wand with "[Hcheck_accept]").
+      replace (checker next_sample)%E with (of_val #true) by admit; iClear "Hcheck_accept".
+      wp_pures.
+      wp_pures.
+      iModIntro; iExists next_sample; iFrame; auto.
+    - (* inductive case; either accept or amplify. *)
+      wp_pures.
+      replace (bool_decide _) with false; last (symmetry; apply bool_decide_eq_false; lia).
+      wp_pures; wp_bind (sampler #())%E.
+      iApply ("Hamplify" $! (generic_geometric_error r 𝜀final (S depth')) with "Hcr").
+      iIntros (next_sample) "!> (%Hnext_sample&[Hcheck_accept|[%𝜀'(Hcr&%H𝜀'&Hcheck_reject)]])"; wp_pures.
+      + (* first case: check accepts *)
+        wp_bind (checker next_sample)%V.
+        Fail iApply (wp_wand with "Hcheck_accept").
+        replace (checker next_sample)%E with (of_val #true) by admit; iClear "Hcheck_accept".
+        wp_pures.
+        wp_pures.
+        iModIntro; iExists next_sample; iFrame; auto.
+      + (* second case: check does not accept but the error amplifies *)
+        wp_bind (checker next_sample)%V.
+        replace (checker next_sample)%E with (of_val #false) by admit; iClear "Hcheck_reject".
+        wp_pures.
+        wp_pure.
+        iSpecialize ("IH" with "[Hcr]").
+        * (* spend the credit *)
+          iApply (ec_spend_irrel with "Hcr").
+          rewrite /generic_geometric_error /=.
+          rewrite /generic_geometric_error /= in H𝜀'.
+          assert (0 <= nonneg r) by (destruct r; auto).
+          apply (Rmult_le_reg_l r); first by lra.
+          (* this is true, but it's being annoying and for some reason lra can't figure it out *)
+          admit.
+        * iClear "#".
+          wp_bind (#(S (S depth'))- #1%nat)%E; wp_pure.
+          replace #((S (S depth')) - 1) with #(S depth'); last first.
+          { do 2 f_equal. rewrite Nat2Z.inj_succ; lia. }
+          iApply "IH".
+  Admitted.
 
 End higherorder.
 
@@ -1420,3 +1506,18 @@ End higherorder_flip2.
 
 
 (* TODO could try an unbounded one? *)
+
+(* read more clutch *)
+
+(* the sampling relational thing *)
+
+(* axiomitize termination with
+   tpref treap (other tpref examples) *)
+
+(* partial rejection sampling
+   resample false clause in SAT
+    something like overlapping variables <-> true
+    => uniform sample of the satisfying instances
+
+  termination
+ *)

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -1,119 +1,117 @@
-(* FIXME stop being such a hoarder *)
 From clutch.app_rel_logic Require Export app_weakestpre primitive_laws.
 From clutch.ub_logic Require Export ub_clutch.
 
-(* Require Import clutch.ub_logic.ub_clutch.
-From stdpp Require Import namespaces.
-From iris.proofmode Require Import proofmode.
-From clutch.prelude Require Import stdpp_ext.
-From clutch.app_rel_logic Require Import lifting ectx_lifting.
-From clutch.prob_lang Require Import lang notation tactics metatheory.
-From clutch.rel_logic Require Export spec_ra.
-*)
-
 Set Default Proof Using "Type*".
-
-(* equivalence between the control flow in the bounded rejection sampler,
-   and the unbounded rejection sampler with error credits *)
-
-Context (PRED_MAX_VALUE: nat).
-Definition MAX_VALUE: nat := S PRED_MAX_VALUE.
 
 Section proofs.
   Local Open Scope R.
   Context `{!clutchGS Σ}.
 
-  (** tapes
-  Definition tapeN ns : tape := (PRED_MAX_VALUE; ns).
-  Definition nat_tape l ns : iProp Σ := l ↪ tapeN ns.
-  Notation "l ↪N ns" := (nat_tape l ns) (at level 20, format "l  ↪N  ns") : bi_scope.
-   *)
+  (* In general:
+      S n' = n
+      S m' = m
+     This notation simplifies the proofs. *)
 
-  (* None when the sampler is in a bad case, SOME #() when in good case *)
-  Definition bdd_cf_rejection_sampler (n m : nat) : val :=
+
+  (** PROGRAMS *)
+
+  (** rejection sampler which takes a preset number of attempts *)
+  Definition bdd_rejection_sampler (n' m' : nat) : val :=
     λ: "depth",
-      (* let: "𝛽" := alloc #m in *)
       let: "do_sample" :=
         (rec: "f" "tries_left" :=
            if: ("tries_left" - #1) < #0
             then NONE
-            else let: "next_sample" := (rand #m from #()) in
-                if: (BinOp LtOp "next_sample" #n)
-                then SOME #()
+            else let: "next_sample" := (rand #m' from #()) in
+                if: ("next_sample" ≤ #n')
+                then SOME "next_sample"
                 else "f" ("tries_left" - #1))
       in "do_sample" "depth".
 
-  (* rejection sampler control flow *)
-  Definition ubdd_cf_rejection_sampler (n m : nat) : val :=
+
+  (** rejection sampler that may take an unbounded number of attempts *)
+  Definition ubdd_rejection_sampler (n' m' : nat) : val :=
     λ: "_",
-      (* let: "𝛽" := alloc #m in *)
       let: "do_sample" :=
         (rec: "f" "_" :=
-           let: "next_sample" := (rand #m from #()) in
-           if: (BinOp LtOp "next_sample" #n)
-            then SOME #()
+           let: "next_sample" := (rand #m' from #()) in
+           if: ("next_sample" ≤ #n')
+            then SOME "next_sample"
             else "f" #())
       in "do_sample" #().
 
-  (* PROBLEM 1: can we prove that unbounded_rejection_samlper_cf always returns Some #()? *)
-  Definition ubdd_cf_safe (n m : nat) E :
-    {{{ True }}} ubdd_cf_rejection_sampler  n m #() @ E {{{ v, RET v ; ⌜ v = SOMEV #()⌝ }}}.
+
+
+
+
+  (** PROBLEM 0: show that the unbounded sampler only returns inbounds values *)
+  Definition ubdd_sampler_safe (n' m' : nat) E :
+    {{{ True }}} ubdd_rejection_sampler  n' m' #() @ E {{{ v, RET v ; ⌜exists v' : nat, v = SOMEV #v' /\ (v' < S n')%nat⌝ }}}.
   Proof.
-    iIntros (Φ) "_ HΦ". rewrite /ubdd_cf_rejection_sampler.
-    (* when we add tapes, why does wp_alloc_tape work? Why can we combine rules from the UB and rel logic? *)
-    (* are they two different logics? are they extensions of the same logic? *)
-    (* wp_apply wp_alloc_tape; [done|]; iIntros (𝛽) "H𝛽". *)
+    iIntros (Φ) "_ HΦ". rewrite /ubdd_rejection_sampler.
     do 4 wp_pure.
     iLöb as "IH"; wp_pures.
-
-    (* this is a regular lob induction proof, we never need to spend any error credits *)
+    (* this is a regular lob induction proof, it does not use error credits *)
     wp_apply wp_rand; [done|]; iIntros (n0) "_".
     wp_pures.
-    case_bool_decide.
-    - wp_pures; by iApply "HΦ".
+    case_bool_decide; last first.
     - wp_pure; by wp_apply ("IH" with "HΦ").
+    - wp_pures; iApply "HΦ"; iModIntro; iPureIntro.
+      exists (fin_to_nat n0); split; [auto|lia].
   Qed.
 
-  (* PROBLEM 2: prove that bounded_rejection_samlper_cf returns Some #() with error *)
 
-  Print nat.
 
+
+  (** PROBLEM 1: show the bounded sampler terminates inbounds with some error *)
+
+  (** nnreal exponents *)
   Fixpoint nnreal_nat_exp (r : nonnegreal) (n : nat) : nonnegreal :=
     match n with
     | O    => nnreal_one
     | S n' => nnreal_mult r (nnreal_nat_exp r n')
     end.
 
-  Definition err_factor n m := (nnreal_div (nnreal_nat (m - n)%nat) (nnreal_nat (S m)%nat)).
+  Lemma nnreal_nat_exp_limit : forall (r 𝜀 : nonnegreal), (r < 1) -> exists n, forall n0, (n0 > n)%nat -> (nnreal_nat_exp r n0) < 𝜀.
+  Proof. (* this is true, how to prove it in the nnreal framework? *) Admitted.
 
-  Lemma err_factor_lt1 n m : err_factor n m < 1.
-  Proof. Admitted.
 
-  (* error for the bounded sampler at a given depth *)
+  (** defining error values for each step *)
+
+  Definition err_factor n m := (nnreal_div (nnreal_nat (m - n)%nat) (nnreal_nat m%nat)).
+
+  Lemma err_factor_lt1 n m (Hn : (0 < n)%nat) (Hnm : (n < m)%nat) : err_factor n m < 1.
+  Proof.
+    rewrite /err_factor.
+    assert (Hdenom : (0 < m)%nat) by lia.
+    assert (Hnum : (m - n < m)%nat) by lia.
+    (* numerator is less than the denominator and they are both positive *)
+  Admitted.
+
+  (* error for the bounded sampler with a given number of tries remaining *)
   Definition bdd_cf_error n m depth := nnreal_nat_exp (err_factor n m) depth.
 
-  (* for proofs which iterate to the very end
-     ie, doing 0 samples requires error tolerance of 1
-   *)
+  (* this lemma is for proofs which iterate to the very end
+     ie, doing 0 samples requires error tolerance of 1 *)
   Lemma bdd_cd_error_final n m : bdd_cf_error n m 0 = nnreal_one.
   Proof. by rewrite /bdd_cf_error /nnreal_nat_exp. Qed.
 
-  (* for proofs which iterate up until the last sample
+  (* this lemma is for proofs which iterate up until the last sample
      ie, a rejection sampler to exclude the final recursive step *)
   Lemma bdd_cd_error_penultimate n m : bdd_cf_error n m 1 = err_factor n m.
   Proof. rewrite /bdd_cf_error /nnreal_nat_exp. (* nnreal: _ * 1 = _ *) Admitted.
 
-  (* how much mass to give to each possibility *)
-  Definition bdd_cf_sampling_error n m 𝜀₁ : (fin (S m)) -> nonnegreal
+  (* distribution of error mass 𝜀₁ for a given sample:
+      - zero error given to cases which are inbounds
+      - uniform error to the recursive case *)
+  Definition bdd_cf_sampling_error n m 𝜀₁ : (fin m) -> nonnegreal
     := fun sample =>
          if (sample <? n)%nat
-            (* good case: needs no error *)
             then nnreal_zero
-            (* recursive case: splits the total mass*)
             else (nnreal_div 𝜀₁ (err_factor n m)).
 
-  (* simplify the accumulated error at a given step *)
-  Lemma simplify_accum_err (n m d': nat) (s : fin (S m))  :
+  (* lemma for simplifying accumulated error in the recursive case *)
+  Lemma simplify_accum_err (n m d': nat) (s : fin m)  :
     (s <? n)%nat = false -> bdd_cf_sampling_error n m (bdd_cf_error n m (S d')) s = (bdd_cf_error n m d' ).
   Proof.
     intros Hcase.
@@ -124,8 +122,8 @@ Section proofs.
   Admitted.
 
 
-  (* each sample is <= 1 provided d > 1 (and the total mass is chosed appropriately) *)
-  Lemma sample_err_wf n m d (s : fin (S m)) : bdd_cf_sampling_error n m (bdd_cf_error n m (S d)) s <= 1.
+  (* error distribution is well-formed for each possible sample *)
+  Lemma sample_err_wf n m d (s : fin m) : bdd_cf_sampling_error n m (bdd_cf_error n m (S d)) s <= 1.
   Proof.
     (* it is either 1, or epsilon times something at most 1 *)
     rewrite /bdd_cf_sampling_error.
@@ -138,10 +136,12 @@ Section proofs.
       admit.
   Admitted.
 
-  (* mean mass is preserved *)
-  Lemma sample_err_mean n m 𝜀₁ :
-    SeriesC (λ s : fin (S m), 1 / S m * bdd_cf_sampling_error n m 𝜀₁ s) = 𝜀₁.
+  (* mean of error distribution is preserved *)
+  Lemma sample_err_mean n' m' 𝜀₁ :
+    SeriesC (λ s : fin (S m'), (1 / S m') * bdd_cf_sampling_error (S n') (S m') 𝜀₁ s) = 𝜀₁.
   Proof.
+    remember (S n') as n.
+    remember (S m') as m.
     rewrite /bdd_cf_sampling_error /err_factor.
     (* split the sum into the elements less than n and those greater *)
     (* sum of constant zero is zero *)
@@ -150,67 +150,189 @@ Section proofs.
 
 
 
-  (* no induction: just see if I can correctly use wp_couple_rand_adv_comp to increase the amount of credit *)
-  Definition bdd_cf_approx_safe_example (n m depth : nat) (Hnm : n <= m) E :
+
+  (** warmup: a finite example *)
+  Definition bdd_approx_safe_finite_example (n' m' depth : nat) (Hnm : (S n' < S m')%nat) E :
     (depth = 3%nat) ->
-    {{{ € (bdd_cf_error n m depth) }}} bdd_cf_rejection_sampler n m #depth @ E {{{ v, RET v ; ⌜ v = SOMEV #() ⌝ }}}.
+    {{{ € (bdd_cf_error (S n') (S m') depth) }}} bdd_rejection_sampler n' m' #(S depth) @ E {{{ v, RET v ; ⌜exists v' : nat, v = SOMEV #v' /\ (v' < S n')%nat⌝ }}}.
   Proof.
-    iIntros (-> Φ) "Hcr HΦ"; rewrite /bdd_cf_rejection_sampler.
-    wp_pures.
+    (* make these off by one errors easier to unpack *)
+    remember (S n') as n.
+    remember (S m') as m.
+    assert (Hn : (0 < n)%nat) by lia.
+    assert (Hm : (0 < m)%nat) by lia.
 
-    (* FIXME somewhere in here is shelves some goals, don't do that. *)
+    iIntros (-> Φ) "Hcr HΦ"; rewrite /bdd_rejection_sampler.
+    wp_pures. rewrite Heqm Heqn.
 
-    (* depth=3 sample *)
-    wp_apply (wp_couple_rand_adv_comp _ _ _ _ _ (bdd_cf_sampling_error _ _ _) with "Hcr"); [apply sample_err_wf|apply sample_err_mean|].
+    (* S depth=3 sample *)
+    wp_apply (wp_couple_rand_adv_comp _ _ _ Φ _ (bdd_cf_sampling_error (S n') _ _) with "Hcr").
+    { apply sample_err_wf. }
+    { pose P := (sample_err_mean n' m' (bdd_cf_error (S n') (S m') 3)); apply P. }
     iIntros (sample) "Hcr".
     wp_pures.
-    case_bool_decide; wp_pures; first by iApply "HΦ".
-    rewrite (simplify_accum_err _); last (apply Nat.ltb_nlt; rewrite /not; intro H'; by apply Nat2Z.inj_lt in H').
+    case_bool_decide; wp_pures.
+    { iApply "HΦ"; iModIntro; iPureIntro; exists (fin_to_nat sample); split; [auto|lia]. }
+    rewrite (simplify_accum_err (S n') (S m') _); last (apply Nat.ltb_nlt; by lia).
 
-    (* depth=2 sample *)
-    wp_apply (wp_couple_rand_adv_comp _ _ _ _ _ (bdd_cf_sampling_error _ _ _) with "Hcr"); [apply sample_err_wf|apply sample_err_mean|].
+    (* S depth=2 sample *)
+    wp_apply (wp_couple_rand_adv_comp _ _ _ Φ _ (bdd_cf_sampling_error (S n') _ _) with "Hcr").
+    { apply sample_err_wf. }
+    { pose P := (sample_err_mean n' m' (bdd_cf_error (S n') (S m') 2)); apply P. }
     iIntros (sample') "Hcr".
     wp_pures.
-    case_bool_decide; wp_pures; first by iApply "HΦ".
-    rewrite (simplify_accum_err _); last (apply Nat.ltb_nlt; rewrite /not; intro H'; by apply Nat2Z.inj_lt in H').
+    case_bool_decide; wp_pures.
+    { iApply "HΦ"; iModIntro; iPureIntro; exists (fin_to_nat sample'); split; [auto|lia]. }
+    rewrite (simplify_accum_err (S n') (S m') _); last (apply Nat.ltb_nlt; by lia).
 
-
-    (* depth=1 sample *)
+    (* S depth=1 sample *)
     rewrite bdd_cd_error_penultimate.
-
-    wp_apply (wp_rand_err_list_nat _ m (seq n (m - n))).
+    rewrite -Heqm -Heqn.
+    wp_apply (wp_rand_err_list_nat _ m' (seq n (m - n))).
     iSplitL "Hcr".
     - (* yeesh *)
       rewrite /err_factor.
       replace (length (seq _ _)) with (m - n)%nat by (symmetry; apply seq_length).
-      replace (S m) with (m + 1)%nat by lia.
+      replace (m) with (m' + 1)%nat by lia.
       done.
     - iIntros (sample'') "%Hsample''".
       wp_pures.
       case_bool_decide; wp_pures.
-      + iApply "HΦ". auto.
-      + exfalso; apply H1.
-        remember (sample'' <? n)%nat as P.
-        destruct P.
-        * apply inj_lt; apply Nat.ltb_lt; done.
-        * (* I don't know if that made it any easier lol *)
-          (* anyways, it's true, but I think the rand_err_list_nat needs to be strengthened
-             since we lost the fact that sample'' : fin (S m) along the way *)
-          admit.
-  Admitted.
+      + iApply "HΦ"; iModIntro; iPureIntro; exists (fin_to_nat sample''); split; [auto|lia].
+      + exfalso.
+        rewrite List.Forall_forall in Hsample''.
+        specialize Hsample'' with sample''.
+        apply Hsample''; last reflexivity.
+        rewrite in_seq.
+        split; first lia.
+        replace (n + (m-n))%nat with m by lia.
+        specialize (fin_to_nat_lt sample''); by lia.
+  Qed.
 
 
-
-  Definition bdd_cf_approx_safe (n m depth: nat) (Hnm : n <= m) E :
-    {{{ € (bdd_cf_error n m depth Hnm) }}} bdd_cf_rejection_sampler n m #depth @ E {{{ v, RET v ; ⌜ v = SOMEV #() ⌝ }}}.
+  (** general case for the bounded sampler *)
+  Definition bdd_approx_safe (n' m' depth : nat) (Hnm : (S n' < S m')%nat) E :
+    {{{ € (bdd_cf_error (S n') (S m') (S depth)) }}} bdd_rejection_sampler n' m' #(S depth)@ E {{{ v, RET v ; ⌜exists v' : nat, v = SOMEV #v' /\ (v' < S n')%nat⌝ }}}.
   Proof.
-    iIntros (Φ) "Hcr HΦ"; rewrite /bdd_cf_rejection_sampler.
+    remember (S n') as n.
+    remember (S m') as m.
+    assert (Hn : (0 < n)%nat) by lia.
+    assert (Hm : (0 < m)%nat) by lia.
+
+    iIntros (Φ) "Hcr HΦ"; rewrite /bdd_rejection_sampler.
     do 4 wp_pure.
-    (* invariant: (bdd_cf_error n m depth Hnm) *  ??? = ??? *)
-    iLöb as "IH".
-  Admitted.
+
+    (* induction should reach the base cse when S depth = 1 <=> depth = 0 *)
+    iInduction depth as [|depth' Hdepth'] "IH".
+    - wp_pures.
+      rewrite bdd_cd_error_penultimate.
+      wp_apply (wp_rand_err_list_nat _ m' (seq n (m - n))).
+      iSplitL "Hcr".
+      + rewrite /err_factor.
+        replace (length (seq _ _)) with (m - n)%nat by (symmetry; apply seq_length).
+        replace (m) with (m' + 1)%nat by lia.
+        done.
+      + iIntros (sample'') "%Hsample''".
+        wp_pures.
+        case_bool_decide; wp_pures.
+        * iApply "HΦ"; iModIntro; iPureIntro; exists (fin_to_nat sample''); split; [auto|lia].
+        * exfalso.
+          rewrite List.Forall_forall in Hsample''.
+          specialize Hsample'' with sample''.
+          apply Hsample''; last reflexivity.
+          rewrite in_seq.
+          split; first lia.
+          replace (n + (m-n))%nat with m by lia.
+          specialize (fin_to_nat_lt sample''); by lia.
+    - wp_pures.
+      replace (bool_decide _) with false; last (symmetry; apply bool_decide_eq_false; lia).
+      wp_pures.
+      wp_apply (wp_couple_rand_adv_comp _ _ _ Φ _ (bdd_cf_sampling_error (S n') _ _) with "Hcr").
+      { apply sample_err_wf. }
+      { pose P := (sample_err_mean n' m' (bdd_cf_error (S n') (S m') _)); rewrite Heqn Heqm; by eapply P. }
+      iIntros (sample') "Hcr".
+      wp_pures.
+      case_bool_decide.
+      + wp_pures; iApply "HΦ"; iModIntro; iPureIntro; exists (fin_to_nat sample'); split; [auto|lia].
+      + wp_pure.
+        rewrite (simplify_accum_err (S n') (S m') _); last (apply Nat.ltb_nlt; by lia).
+        wp_bind (#_ - #_)%E. wp_pure.
+        replace (S (S depth') - 1)%Z with (Z.of_nat (S depth')) by lia.
+        rewrite Heqn Heqm.
+        wp_apply ("IH" with "Hcr HΦ").
+  Qed.
 
 
+
+  (** PROBLEM 3: show that the unbounded approximate sampler is safe if we have enough error to eliminate past a depth *)
+  Definition ubdd_approx_safe (n' m' depth : nat) (Hnm : (S n' < S m')%nat) E :
+    {{{ € (bdd_cf_error (S n') (S m') (S depth)) }}} ubdd_rejection_sampler n' m' #() @ E {{{ v, RET v ; ⌜exists v' : nat, v = SOMEV #v' /\ (v' < S n')%nat⌝  }}}.
+  Proof.
+    remember (S n') as n.
+    remember (S m') as m.
+    assert (Hn : (0 < n)%nat) by lia.
+    assert (Hm : (0 < m)%nat) by lia.
+
+    iIntros (Φ) "Hcr HΦ"; rewrite /ubdd_rejection_sampler.
+    do 4 wp_pure.
+
+    iInduction depth as [|depth' Hdepth'] "IH".
+    - wp_pures.
+      rewrite bdd_cd_error_penultimate.
+      wp_apply (wp_rand_err_list_nat _ m' (seq n (m - n))).
+      iSplitL "Hcr".
+      + rewrite /err_factor.
+        replace (length (seq _ _)) with (m - n)%nat by (symmetry; apply seq_length).
+        replace (m) with (m' + 1)%nat by lia.
+        done.
+      + iIntros (sample'') "%Hsample''".
+        wp_pures.
+        case_bool_decide; wp_pures.
+        * iApply "HΦ"; iModIntro; iPureIntro; exists (fin_to_nat sample''); split; [auto|lia].
+        * exfalso.
+          rewrite List.Forall_forall in Hsample''.
+          specialize Hsample'' with sample''.
+          apply Hsample''; last reflexivity.
+          rewrite in_seq.
+          split; first lia.
+          replace (n + (m-n))%nat with m by lia.
+          specialize (fin_to_nat_lt sample''); by lia.
+    - wp_pures.
+      wp_apply (wp_couple_rand_adv_comp _ _ _ Φ _ (bdd_cf_sampling_error (S n') _ _) with "Hcr").
+      { apply sample_err_wf. }
+      { pose P := (sample_err_mean n' m' (bdd_cf_error (S n') (S m') _)); rewrite Heqn Heqm; by eapply P. }
+      iIntros (sample') "Hcr".
+      wp_pures.
+      case_bool_decide.
+      + wp_pures. iApply "HΦ"; iModIntro; iPureIntro; exists (fin_to_nat sample'); split; [auto|lia].
+      + wp_pure.
+        rewrite (simplify_accum_err (S n') (S m') _); last (apply Nat.ltb_nlt; by lia).
+        rewrite Heqn Heqm.
+        wp_apply ("IH" with "Hcr HΦ").
+  Qed.
+
+
+  (** PROBLEM 4: show that any positive error 𝜀 suffices to make the unbounded sampler terminate inbounds *)
+  Theorem ubdd_cf_safety (n' m' : nat) (Hnm : (S n' < S m')%nat) E : forall 𝜀,
+    ⊢ {{{ €𝜀 ∗ ⌜𝜀 > 0 ⌝  }}} ubdd_rejection_sampler n' m' #()@ E {{{ v, RET v ; ⌜exists v' : nat, v = SOMEV #v' /\ (v' < S n')%nat⌝ }}}.
+  Proof.
+    iIntros (𝜀 Φ) " !> (Hcr&%Hcrpos) HΦ".
+    destruct (nnreal_nat_exp_limit (err_factor (S n') (S m')) 𝜀) as [d].
+    - apply err_factor_lt1; lia.
+    - iApply (ubdd_approx_safe with "[Hcr] [HΦ]"); auto.
+      iApply ec_weaken; last iAssumption.
+      rewrite /bdd_cf_error.
+      apply Rlt_le.
+      specialize H with (S d); apply H; lia.
+  Qed.
+
+
+  (* PROBLEM ??: If error credits can rule out nontermination we could show that the unbounded
+     rejection sampler doesn't terminate with probability zero (in the UB logic)  *)
+
+  (* PROBLEM ??: We should be able to prove:
+        - the unbounded sampler is equivalent to the bounded sampler with a given error
+        - the bounded sampler is equivalent to a single sample with a given error
+      in the approximate relational logic. *)
 
 End proofs.
-

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -247,6 +247,12 @@ Section finSeries.
         done.
   Qed.
 
+  (* almost certainly this is the better way to prove the above *)
+  Lemma SeriesC_finite_foldr `{Finite A} (f : A → R) :
+    SeriesC f = foldr (Rplus ∘ f) 0%R (enum A).
+  Proof. (* proven in the tpref branch *) Admitted.
+
+
 End finSeries.
 
 
@@ -1199,9 +1205,15 @@ Section higherorder_flip2.
     iIntros (Φ) "Hcr HΦ".
     iApply (wp_couple_rand_adv_comp 1%nat  _ _ _ 𝜀1 (𝜀2_flip2 𝜀1) _ with "Hcr").
     - (* uniform bound *)
-      admit.
+      pose bound := (nnreal_nat 2 * 𝜀1)%NNR.
+      exists bound; intros n.
+      rewrite /𝜀2_flip2.
+      destruct (fin_to_bool n).
+      + destruct bound; auto.
+      + rewrite /bound /=; lra.
     - (* series mean *)
-      admit.
+      rewrite SeriesC_finite_foldr /enum /fin_finite /fin_enum /=.
+      lra.
     - (* continutation *)
       iNext. iIntros (n) "Hcr".
       iApply ("HΦ" $! (fin_to_nat n)); iSplitR.
@@ -1215,7 +1227,11 @@ Section higherorder_flip2.
         * rewrite -fin2_nat_bool.
           replace (n =? 1)%nat with true; last by (symmetry; apply Nat.eqb_eq; lia).
           rewrite /scale_unless H /=; done.
-  Admitted.
+      Unshelve.
+      { apply Φ. }
+      { apply TCEq_refl. }
+
+  Qed.
 
 
   Lemma flip2_sampling_scheme_spec E :

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -1245,8 +1245,8 @@ Section higherorder_flip2.
       exists bound; intros n.
       rewrite /𝜀2_flip1.
       destruct (fin_to_bool n).
-      + destruct bound. admit.
-      + destruct bound. admit.
+      + destruct 𝜀t as [𝜀tv H𝜀tvpos]. rewrite /bound /=. lra.
+      + destruct 𝜀h as [𝜀hv H𝜀hvpos]. rewrite /bound /=. lra.
     - (* series mean *)
       rewrite SeriesC_finite_foldr /enum /fin_finite /fin_enum /𝜀2_flip1 /=.
       lra.
@@ -1267,7 +1267,7 @@ Section higherorder_flip2.
       Unshelve.
       { apply Φ. }
       { apply TCEq_refl. }
-  Admitted.
+  Qed.
 
 
   Lemma flip2_sampling_scheme_spec E :
@@ -1281,11 +1281,7 @@ Section higherorder_flip2.
     iIntros (Φ) "_ HΦ"; wp_pures; iModIntro; iApply "HΦ".
 
     iSplit.
-    { (* amplification: apply the other amplification lemma twice?
-         multiply by 2 twice => multiply by 4
-         so my initial error should be (3/4) * (1/4)^depth?
-       *)
-      iIntros (𝜀1 post) "!> Hcr Hpost".
+    { iIntros (𝜀1 post) "!> Hcr Hpost".
       wp_pures.
       wp_bind (rand #1 from #())%E.
       (* amplify: give 4/3 error to the false branch, and 2/3 error to the second *)

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -305,18 +305,28 @@ Section basic.
       - replace (@Hierarchy.sum_n_m  Hierarchy.R_AbelianGroup (countable_sum (λ n0 : nat, f n0)) 0 N')
           with  (@Hierarchy.sum_n_m  Hierarchy.R_AbelianGroup (λ n0 : nat, 0) 0 N').
           { rewrite (Hierarchy.sum_n_m_const _ _ 0); rewrite Rmult_0_r; auto. }
-          (* their extensionality is too weak... it claims equality at all points rather than
-                just those on the sum indices *)
-            (* apply Hierarchy.sum_n_m_ext.
-            intros.
-            apply countable_sum_ext; intros.
-            symmetry; apply Hinit. *)
-            admit. }
+            apply Hierarchy.sum_n_m_ext_loc.
+            intros K Hk.
+            rewrite /countable_sum.
+            (* I can simplify this with some of my lemmas now? *)
+            rewrite encode_inv_nat_nat_total /=.
+            symmetry; apply Hinit.
+            lia. }
 
-    (* now it's the reindexing problem *)
-    admit.
+    induction n as [| n' IH].
+    - simpl.
+      do 2 (rewrite Hierarchy.sum_n_n).
+      (* now we do the song and dance to evaluate the countable_sum at a value again *)
+      rewrite /countable_sum encode_inv_nat_nat_total /=.
+      replace (N + 0)%nat with N%nat by lia.
+      reflexivity.
+    - simpl.
+      do 2 (rewrite Hierarchy.sum_n_Sm; last by lia).
+      f_equal; first by apply IH.
+      do 2 (rewrite /countable_sum encode_inv_nat_nat_total /=).
+      f_equal; lia.
+  Qed.
 
-  Admitted.
 
 
   (* mean of error distribution is preserved *)
@@ -353,7 +363,7 @@ Section basic.
   Admitted.
 
 
-
+(*
 Lemma SeriesC_leq (N : nat) (v : R) :
   Series (λ (n : nat), if bool_decide (n < N)%nat then v else 0) = INR N * v.
 Proof.
@@ -369,6 +379,7 @@ Proof.
     rewrite Rplus_0_l.
     apply Series_singleton.
 Qed.
+*)
 
 
 
@@ -594,7 +605,11 @@ Section higherorder.
               {{{ € 𝜀1 }}} e @ E {{{ v, RET v; ⌜Ψ v = true ⌝ ∗ € (𝜀2 v) }}}.
 
   (* this should suffice to prove part of the sampling scheme spec for other examples
-     (IE we'd admit this) *)
+     (IE we'd admit this for a sampler, or prove it some other way, and we can use the
+      higher order spec)
+
+     could we prove this? what might go wrong? Do we need any other hypotheses?
+   *)
 
 
 
@@ -606,7 +621,6 @@ Section higherorder.
          e @ E
        {{{sampler checker, RET (PairV sampler checker);
             (* sampler needs to be able to amplify the mass during sampling *)
-            (* (∀ 𝜀1, wp_couple_generic_adv_comp Ψ ((Val sampler) #())%E 𝜀1 (scale_unless 𝜀 𝜀1 Θ) E) ∗ *)
             (∀ 𝜀1, {{{€  𝜀1}}} ((Val sampler) #())%E @ E {{{ v, RET v; ⌜Ψ v = true ⌝ ∗ € (scale_unless 𝜀 𝜀1 Θ v) }}}) ∗
             (* Θ reflects checker whenever the value is one we could have sampled *)
             (∀ v : val, {{{ ⌜Ψ v = true⌝ }}} ((Val checker) v) @ E {{{ b, RET #b; ⌜b = Θ v⌝ }}}) ∗

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -5,7 +5,258 @@ Require Import Lra.
 
 Set Default Proof Using "Type*".
 
+
+Section finite.
+  (* generalization of Coq.Logic.FinFun: lift functions over fin to functions over nat *)
+  Definition f_lift_fin_nat {A} (N : nat) (a : A) (f : fin N -> A) : (nat -> A) :=
+    fun n =>
+      match le_lt_dec N n with
+      | left _ => a
+      | right h => f (Fin.of_nat_lt h)
+      end.
+
+
+  (* uses proof irrelevance *)
+  Lemma f_lift_fin_nat_ltN {A} (n N: nat) (a : A) (Hn : (n < N)%nat) f :
+    (f_lift_fin_nat N a f) n = f (nat_to_fin Hn).
+  Proof.
+    rewrite /f_lift_fin_nat.
+    destruct (le_lt_dec N n) as [Hl|Hr].
+    - lia.
+    - f_equal; f_equal.
+      apply proof_irrelevance.
+  Qed.
+
+
+  Lemma f_lift_fin_nat_geN {A} (N n: nat) (a : A) (Hn : not (n < N)%nat) f :
+    (f_lift_fin_nat N a f) n = a.
+  Proof.
+    rewrite /f_lift_fin_nat.
+    destruct (le_lt_dec N n); [done | lia].
+  Qed.
+
+
+  Lemma encode_inv_nat_nat_total (n : nat) : (@encode_inv_nat nat _ _ n)  = Some n.
+  Proof.
+    rewrite -encode_inv_encode_nat.
+    f_equal.
+    rewrite /encode_nat.
+    rewrite /encode /nat_countable.
+    destruct n; try done.
+    rewrite /= /encode /N_countable /= -SuccNat2Pos.inj_succ.
+    symmetry; apply SuccNat2Pos.pred_id.
+  Qed.
+
+  Lemma encode_inv_nat_fin_undef (n N: nat) (H : not (n < N)%nat) : (@encode_inv_nat (fin N) _ _ n) = None.
+  Proof.
+    apply encode_inv_decode_ge.
+    rewrite fin_card.
+    lia.
+  Qed.
+
+
+  Lemma encode_inv_nat_fin_total (n N: nat) (H : (n < N)%nat) : (@encode_inv_nat (fin N) _ _ n) = Some (nat_to_fin H).
+  Proof.
+    (* maybe I turn it into an encode_nat problem? is that easier than encode_inv_nat? *)
+    rewrite -encode_inv_encode_nat; f_equal.
+
+    (* Set Printing Coercions. *)
+
+    Check nat_to_fin_to_nat.
+
+
+    (* even though this looks promising, I think it's going nowhere because the a is under an existential.
+    assert (H' : (n < card (fin N))%nat).
+    { by rewrite fin_card. }
+    destruct (@encode_inv_decode (fin N) _ _ n H') as [a Ha].
+    *)
+
+    rewrite /encode_nat.
+    rewrite /encode. simpl.
+    rewrite Nat2Pos.id; try lia.
+    rewrite -pred_Sn.
+    replace (fst <$> _) with (Some n); first by simpl.
+    replace (list_find _ _) with (Some (n, nat_to_fin H)); first by simpl.
+    symmetry; rewrite list_find_Some.
+    induction n as [|n' IH].
+    - split. { destruct N; simpl; [lia | done]. }
+      split. { done. }
+      intros ? ? ? Hcontra; lia.
+    - split. {
+        assert (H' : (n' < N)%nat) by lia.
+        destruct (IH H') as [HR _ _].
+        (* now HR tells us how to lookup at n'... we need to unroll the lookup one level *)
+
+        rewrite -lookup_tail.
+        (* somehow we need to pull out the fact that tail of (fin_enum (S N)) is FS <$> (fin_enum N), right? *)
+
+        rewrite /fin_enum.
+        induction N; try lia.
+        simpl.
+        fold fin_enum.
+        (* literally no idea how I'm going to apply that IH because I'm not even sure S n' < N is true *)
+        rewrite list_lookup_fmap.
+
+
+        admit.
+
+      }
+      split. { done. }
+      admit.
+  Admitted.
+
+
+
+  Lemma fin2_enum (x : fin 2) : (fin_to_nat x = 0%nat) \/ (fin_to_nat x = 1%nat).
+  Proof.
+  Admitted.
+
+  Lemma fin2_nat_bool (x : fin 2) : (fin_to_nat x =? 1)%nat = (fin_to_bool x).
+  Proof. Admitted.
+
+
+
+End finite.
+
+
+Section finSeries.
+  Local Open Scope R.
+
+  (* increment the index of a series whose first terms are zero *)
+  Lemma series_incr_N_zero f N :
+    (forall m : nat, (m < N)%nat -> f m = 0) -> SeriesC (fun n : nat => f n) = SeriesC (fun n : nat => f (N + n)%nat).
+  Proof.
+    intros Hinit.
+    rewrite /SeriesC /Series.
+    rewrite -(Lim_seq.Lim_seq_incr_n (λ n : nat, @Hierarchy.sum_n Hierarchy.R_AbelianGroup _ _) N).
+    f_equal; apply Lim_seq.Lim_seq_ext; intros n.
+    rewrite /Hierarchy.sum_n.
+    replace (@Hierarchy.sum_n_m Hierarchy.R_AbelianGroup (countable_sum (λ n0 : nat, f n0)) 0 (n + N))
+      with (@Hierarchy.sum_n_m Hierarchy.R_AbelianGroup (countable_sum (λ n0 : nat, f n0)) N (n + N));
+      last first.
+    { destruct N as [|N']; first by simpl.
+      rewrite (Hierarchy.sum_n_m_Chasles _ 0%nat N' (n + S N')%nat); try lia.
+      replace  (@Hierarchy.sum_n_m Hierarchy.R_AbelianGroup (countable_sum (λ n0 : nat, f n0)) 0 N')
+          with (@Hierarchy.zero Hierarchy.R_AbelianGroup).
+      - by rewrite Hierarchy.plus_zero_l.
+      - replace (@Hierarchy.sum_n_m  Hierarchy.R_AbelianGroup (countable_sum (λ n0 : nat, f n0)) 0 N')
+          with  (@Hierarchy.sum_n_m  Hierarchy.R_AbelianGroup (λ n0 : nat, 0) 0 N').
+          { rewrite (Hierarchy.sum_n_m_const _ _ 0); rewrite Rmult_0_r; auto. }
+            apply Hierarchy.sum_n_m_ext_loc.
+            intros K Hk.
+            rewrite /countable_sum.
+            (* I can simplify this with some of my lemmas now? *)
+            rewrite encode_inv_nat_nat_total /=.
+            symmetry; apply Hinit.
+            lia. }
+
+    induction n as [| n' IH].
+    - simpl.
+      do 2 (rewrite Hierarchy.sum_n_n).
+      (* now we do the song and dance to evaluate the countable_sum at a value again *)
+      rewrite /countable_sum encode_inv_nat_nat_total /=.
+      replace (N + 0)%nat with N%nat by lia.
+      reflexivity.
+    - simpl.
+      do 2 (rewrite Hierarchy.sum_n_Sm; last by lia).
+      f_equal; first by apply IH.
+      do 2 (rewrite /countable_sum encode_inv_nat_nat_total /=).
+      f_equal; lia.
+  Qed.
+
+
+  (* reindex a series over fin which is zero below some value *)
+  Lemma reindex_fin_series M z K (Hnm : ((S z) < M)%nat):
+    SeriesC (fun x : fin M => nonneg (if bool_decide (x < (S z))%nat then nnreal_zero else K))
+      = SeriesC (fun x : fin (M-(S z)) => nonneg K).
+  Proof.
+    remember (S z) as N.
+    (* try to do the same induction dance as the reindexing part of the above lemma *)
+    rewrite /SeriesC /Series.
+    f_equal.
+    (* after we increment the top sum by N, they are pointwise equal *)
+    rewrite -(Lim_seq.Lim_seq_incr_n (λ n : nat, @Hierarchy.sum_n Hierarchy.R_AbelianGroup _ _) N).
+    apply Lim_seq.Lim_seq_ext; intros n.
+
+    (* rewrite to a two-ended sum, and compute the first N terms to be zero like above *)
+
+    induction n as [| n' IH].
+    - (* split the sum into the zero part, and the singular term of value K *)
+      rewrite /= HeqN Hierarchy.sum_Sn -HeqN.
+
+      (* now we can evaluate the first handful of terms to be zero *)
+
+      rewrite Hierarchy.sum_O.
+      remember (fun x : fin M => nonneg $ if bool_decide (x < N)%nat then nnreal_zero else K) as body.
+      remember (fun _ : fin M => nnreal_zero) as body1.
+      replace
+        (@Hierarchy.sum_n Hierarchy.R_AbelianGroup (countable_sum body) z)
+      with
+        (@Hierarchy.sum_n Hierarchy.R_AbelianGroup (countable_sum body1) z);
+      last first.
+      { apply Hierarchy.sum_n_ext_loc.
+        intros n Hn.
+        rewrite /countable_sum.
+        rewrite encode_inv_nat_fin_total; first lia.
+        intros Hn1.
+        rewrite /= Heqbody1 Heqbody HeqN fin_to_nat_to_fin /=.
+        rewrite bool_decide_true; first done.
+        lia. }
+
+      (* now we can replace the countable sum with a constant zero function (TODO: make me a lemma)*)
+      rewrite Heqbody1.
+      replace
+        (@countable_sum (Fin.t M) (@fin_dec M) (@finite_countable (Fin.t M) (@fin_dec M) (fin_finite M))
+          (fun _ : Fin.t M => nonneg nnreal_zero))
+      with (fun _ : nat => 0); last first.
+      { apply functional_extensionality.
+        intros x; rewrite /countable_sum.
+        destruct (encode_inv_nat x) as [t|]; by simpl. }
+
+      (* now the two series are both constant zero, we cam simplify *)
+      rewrite Hierarchy.sum_n_const Rmult_0_r.
+      rewrite /countable_sum.
+
+      do 2 (rewrite encode_inv_nat_fin_total; try lia).
+      intros H''.
+      rewrite /= Heqbody fin_to_nat_to_fin /=.
+      rewrite bool_decide_false; try lia.
+      rewrite Hierarchy.plus_zero_l.
+      done.
+    - simpl.
+      rewrite Hierarchy.sum_Sn.
+      rewrite Hierarchy.sum_Sn.
+      f_equal; first by apply IH.
+      remember (bool_decide (S n' < (M - N))%nat) as HCond1.
+      case_bool_decide.
+      + rewrite {2}/countable_sum.
+        rewrite encode_inv_nat_fin_total.
+        simpl.
+        rewrite /countable_sum.
+        rewrite encode_inv_nat_fin_total; try lia.
+        intros H''.
+        remember (nat_to_fin H'') as D.
+        simpl.
+        rewrite bool_decide_false; first done.
+        rewrite HeqD.
+        rewrite fin_to_nat_to_fin.
+        lia.
+      + rewrite /countable_sum.
+        rewrite encode_inv_nat_fin_undef; last lia.
+        rewrite encode_inv_nat_fin_undef; last auto.
+        done.
+  Qed.
+
+End finSeries.
+
+
+
+
+
 Section basic.
+  (* basic version of the rejection sampler, bounded and unbounded *)
+
+
   Local Open Scope R.
   Context `{!clutchGS Σ}.
 
@@ -180,13 +431,6 @@ Section basic.
       + apply err_factor_nz_R; auto.
   Qed.
 
-  (* generalization of Coq.Logic.FinFun *)
-  Definition f_lift_fin_nat {A} (N : nat) (a : A) (f : fin N -> A) : (nat -> A) :=
-    fun n =>
-      match le_lt_dec N n with
-      | left _ => a
-      | right h => f (Fin.of_nat_lt h)
-      end.
 
 
   (* uses proof irrelevance *)
@@ -577,13 +821,27 @@ End basic.
 
 
 
+
 Section higherorder.
+  (* higher order rejection sampling *)
   Local Open Scope R.
   Context `{!clutchGS Σ}.
+
+  (* spending error credits is proof irrelevant *)
+  Lemma ec_spend_irrel a b : (nonneg b <= nonneg a) -> € a -∗ € b.
+  Proof. iIntros (H) "?". iApply (ec_weaken _ H). iFrame. Qed.
+
+
+  Lemma credit_spend_1 : €nnreal_one -∗ ▷ False.
+  Proof. Admitted.
 
 
   Definition scale_unless (𝜀 𝜀1 : nonnegreal) (Θ : val -> bool) : val -> nonnegreal
     := (fun z => if (Θ z) then nnreal_zero else (nnreal_div 𝜀1 𝜀)%NNR).
+
+  Lemma scale_unless_cmp a b 𝜀 v Θ : (scale_unless b (scale_unless a 𝜀 Θ #v) Θ #v) = (scale_unless (a*b)%NNR 𝜀 Θ #v).
+  Proof. Admitted.
+
 
   Definition sampling_scheme_spec (e : expr) 𝜀factor 𝜀final E (Ψ : val -> bool) (Θ : val -> bool) : Prop
     := {{{ True }}}
@@ -717,6 +975,7 @@ End higherorder.
 
 
 Section higherorder_rand.
+  (* higher order version of the basic rejection sampler *)
   Local Open Scope R.
   Context `{!clutchGS Σ}.
 
@@ -898,9 +1157,9 @@ End higherorder_rand.
 
 
 Section higherorder_flip2.
+  (* higher order version of a sampler which rejects until two coin flips are 1 *)
   Local Open Scope R.
   Context `{!clutchGS Σ}.
-
 
   Definition flip2_sampling_scheme : expr
      := (λ: "_",  (Pair
@@ -932,23 +1191,6 @@ Section higherorder_flip2.
       else (nnreal_nat(2%nat) * 𝜀1)%NNR.
 
 
-  Lemma fin2_enum (x : fin 2) : (fin_to_nat x = 0%nat) \/ (fin_to_nat x = 1%nat).
-  Proof. Admitted.
-
-  Lemma fin2_nat_bool0 (x : fin 2) : (fin_to_nat x = 0%nat) <-> (fin_to_bool x = false).
-  Proof. Admitted.
-
-  Lemma fin2_nat_bool1(x : fin 2) : (fin_to_nat x = 1%nat) <-> (fin_to_bool x = true).
-  Proof. Admitted.
-
-
-  Lemma scale_unless_cmp a b 𝜀 v Θ : (scale_unless b (scale_unless a 𝜀 Θ #v) Θ #v) = (scale_unless (a*b)%NNR 𝜀 Θ #v).
-  Proof. Admitted.
-
-  Lemma ec_spend_irrel a b : (nonneg b <= nonneg a) -> € a -∗ € b.
-  Proof. iIntros (H) "?". iApply (ec_weaken _ H). iFrame. Qed.
-
-
   Lemma flip_amplification (𝜀1 : nonnegreal) E :
     {{{ € 𝜀1 }}}
       rand #1 from #() @ E
@@ -966,9 +1208,12 @@ Section higherorder_flip2.
       + iPureIntro; apply fin2_enum.
       + iApply (ec_spend_irrel with "Hcr"). rewrite /𝜀2_flip2.
         destruct (fin2_enum n) as [H|H].
-        * replace (fin_to_bool n) with false; last (symmetry; by apply fin2_nat_bool0).
-          rewrite /scale_unless H /= Rmult_1_l Rmult_comm Rinv_inv. apply Req_le_sym; by apply Rmult_eq_compat_l.
-        * replace (fin_to_bool n) with true; last (symmetry; by apply fin2_nat_bool1).
+        * rewrite -fin2_nat_bool.
+          replace (n =? 1)%nat with false; last by (symmetry; apply Nat.eqb_neq; lia).
+          rewrite /scale_unless H /= Rmult_1_l Rmult_comm Rinv_inv.
+          apply Req_le_sym; apply Rmult_eq_compat_l; done.
+        * rewrite -fin2_nat_bool.
+          replace (n =? 1)%nat with true; last by (symmetry; apply Nat.eqb_eq; lia).
           rewrite /scale_unless H /=; done.
   Admitted.
 

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -1,0 +1,216 @@
+(* FIXME stop being such a hoarder *)
+From clutch.app_rel_logic Require Export app_weakestpre primitive_laws.
+From clutch.ub_logic Require Export ub_clutch.
+
+(* Require Import clutch.ub_logic.ub_clutch.
+From stdpp Require Import namespaces.
+From iris.proofmode Require Import proofmode.
+From clutch.prelude Require Import stdpp_ext.
+From clutch.app_rel_logic Require Import lifting ectx_lifting.
+From clutch.prob_lang Require Import lang notation tactics metatheory.
+From clutch.rel_logic Require Export spec_ra.
+*)
+
+Set Default Proof Using "Type*".
+
+(* equivalence between the control flow in the bounded rejection sampler,
+   and the unbounded rejection sampler with error credits *)
+
+Context (PRED_MAX_VALUE: nat).
+Definition MAX_VALUE: nat := S PRED_MAX_VALUE.
+
+Section proofs.
+  Local Open Scope R.
+  Context `{!clutchGS Σ}.
+
+  (** tapes
+  Definition tapeN ns : tape := (PRED_MAX_VALUE; ns).
+  Definition nat_tape l ns : iProp Σ := l ↪ tapeN ns.
+  Notation "l ↪N ns" := (nat_tape l ns) (at level 20, format "l  ↪N  ns") : bi_scope.
+   *)
+
+  (* None when the sampler is in a bad case, SOME #() when in good case *)
+  Definition bdd_cf_rejection_sampler (n m : nat) : val :=
+    λ: "depth",
+      (* let: "𝛽" := alloc #m in *)
+      let: "do_sample" :=
+        (rec: "f" "tries_left" :=
+           if: ("tries_left" - #1) < #0
+            then NONE
+            else let: "next_sample" := (rand #m from #()) in
+                if: (BinOp LtOp "next_sample" #n)
+                then SOME #()
+                else "f" ("tries_left" - #1))
+      in "do_sample" "depth".
+
+  (* rejection sampler control flow *)
+  Definition ubdd_cf_rejection_sampler (n m : nat) : val :=
+    λ: "_",
+      (* let: "𝛽" := alloc #m in *)
+      let: "do_sample" :=
+        (rec: "f" "_" :=
+           let: "next_sample" := (rand #m from #()) in
+           if: (BinOp LtOp "next_sample" #n)
+            then SOME #()
+            else "f" #())
+      in "do_sample" #().
+
+  (* PROBLEM 1: can we prove that unbounded_rejection_samlper_cf always returns Some #()? *)
+  Definition ubdd_cf_safe (n m : nat) E :
+    {{{ True }}} ubdd_cf_rejection_sampler  n m #() @ E {{{ v, RET v ; ⌜ v = SOMEV #()⌝ }}}.
+  Proof.
+    iIntros (Φ) "_ HΦ". rewrite /ubdd_cf_rejection_sampler.
+    (* when we add tapes, why does wp_alloc_tape work? Why can we combine rules from the UB and rel logic? *)
+    (* are they two different logics? are they extensions of the same logic? *)
+    (* wp_apply wp_alloc_tape; [done|]; iIntros (𝛽) "H𝛽". *)
+    do 4 wp_pure.
+    iLöb as "IH"; wp_pures.
+
+    (* this is a regular lob induction proof, we never need to spend any error credits *)
+    wp_apply wp_rand; [done|]; iIntros (n0) "_".
+    wp_pures.
+    case_bool_decide.
+    - wp_pures; by iApply "HΦ".
+    - wp_pure; by wp_apply ("IH" with "HΦ").
+  Qed.
+
+  (* PROBLEM 2: prove that bounded_rejection_samlper_cf returns Some #() with error *)
+
+  Print nat.
+
+  Fixpoint nnreal_nat_exp (r : nonnegreal) (n : nat) : nonnegreal :=
+    match n with
+    | O    => nnreal_one
+    | S n' => nnreal_mult r (nnreal_nat_exp r n')
+    end.
+
+  Definition err_factor n m := (nnreal_div (nnreal_nat (m - n)%nat) (nnreal_nat (S m)%nat)).
+
+  Lemma err_factor_lt1 n m : err_factor n m < 1.
+  Proof. Admitted.
+
+  (* error for the bounded sampler at a given depth *)
+  Definition bdd_cf_error n m depth := nnreal_nat_exp (err_factor n m) depth.
+
+  (* for proofs which iterate to the very end
+     ie, doing 0 samples requires error tolerance of 1
+   *)
+  Lemma bdd_cd_error_final n m : bdd_cf_error n m 0 = nnreal_one.
+  Proof. by rewrite /bdd_cf_error /nnreal_nat_exp. Qed.
+
+  (* for proofs which iterate up until the last sample
+     ie, a rejection sampler to exclude the final recursive step *)
+  Lemma bdd_cd_error_penultimate n m : bdd_cf_error n m 1 = err_factor n m.
+  Proof. rewrite /bdd_cf_error /nnreal_nat_exp. (* nnreal: _ * 1 = _ *) Admitted.
+
+  (* how much mass to give to each possibility *)
+  Definition bdd_cf_sampling_error n m 𝜀₁ : (fin (S m)) -> nonnegreal
+    := fun sample =>
+         if (sample <? n)%nat
+            (* good case: needs no error *)
+            then nnreal_zero
+            (* recursive case: splits the total mass*)
+            else (nnreal_div 𝜀₁ (err_factor n m)).
+
+  (* simplify the accumulated error at a given step *)
+  Lemma simplify_accum_err (n m d': nat) (s : fin (S m))  :
+    (s <? n)%nat = false -> bdd_cf_sampling_error n m (bdd_cf_error n m (S d')) s = (bdd_cf_error n m d' ).
+  Proof.
+    intros Hcase.
+    rewrite /bdd_cf_sampling_error Hcase /bdd_cf_error {1}/nnreal_nat_exp -/nnreal_nat_exp.
+    remember (err_factor n m) as X.
+    remember (nnreal_nat_exp X d') as Y.
+    (* nnreal: X * Y  / X = Y *)
+  Admitted.
+
+
+  (* each sample is <= 1 provided d > 1 (and the total mass is chosed appropriately) *)
+  Lemma sample_err_wf n m d (s : fin (S m)) : bdd_cf_sampling_error n m (bdd_cf_error n m (S d)) s <= 1.
+  Proof.
+    (* it is either 1, or epsilon times something at most 1 *)
+    rewrite /bdd_cf_sampling_error.
+    remember (s <? n)%nat as H.
+    destruct H.
+    - admit. (* nnreal: 0 < 1 *)
+    - rewrite /bdd_cf_error.
+      (* nnreal: this is true because we can pull out a factor from the exponent, and the remainder is
+         a natural power of a number less than 1. *)
+      admit.
+  Admitted.
+
+  (* mean mass is preserved *)
+  Lemma sample_err_mean n m 𝜀₁ :
+    SeriesC (λ s : fin (S m), 1 / S m * bdd_cf_sampling_error n m 𝜀₁ s) = 𝜀₁.
+  Proof.
+    rewrite /bdd_cf_sampling_error /err_factor.
+    (* split the sum into the elements less than n and those greater *)
+    (* sum of constant zero is zero *)
+    (* after simplification, the other sum has m-n elements at constant (𝜀₁/m-n) *)
+  Admitted.
+
+
+
+  (* no induction: just see if I can correctly use wp_couple_rand_adv_comp to increase the amount of credit *)
+  Definition bdd_cf_approx_safe_example (n m depth : nat) (Hnm : n <= m) E :
+    (depth = 3%nat) ->
+    {{{ € (bdd_cf_error n m depth) }}} bdd_cf_rejection_sampler n m #depth @ E {{{ v, RET v ; ⌜ v = SOMEV #() ⌝ }}}.
+  Proof.
+    iIntros (-> Φ) "Hcr HΦ"; rewrite /bdd_cf_rejection_sampler.
+    wp_pures.
+
+    (* FIXME somewhere in here is shelves some goals, don't do that. *)
+
+    (* depth=3 sample *)
+    wp_apply (wp_couple_rand_adv_comp _ _ _ _ _ (bdd_cf_sampling_error _ _ _) with "Hcr"); [apply sample_err_wf|apply sample_err_mean|].
+    iIntros (sample) "Hcr".
+    wp_pures.
+    case_bool_decide; wp_pures; first by iApply "HΦ".
+    rewrite (simplify_accum_err _); last (apply Nat.ltb_nlt; rewrite /not; intro H'; by apply Nat2Z.inj_lt in H').
+
+    (* depth=2 sample *)
+    wp_apply (wp_couple_rand_adv_comp _ _ _ _ _ (bdd_cf_sampling_error _ _ _) with "Hcr"); [apply sample_err_wf|apply sample_err_mean|].
+    iIntros (sample') "Hcr".
+    wp_pures.
+    case_bool_decide; wp_pures; first by iApply "HΦ".
+    rewrite (simplify_accum_err _); last (apply Nat.ltb_nlt; rewrite /not; intro H'; by apply Nat2Z.inj_lt in H').
+
+
+    (* depth=1 sample *)
+    rewrite bdd_cd_error_penultimate.
+
+    wp_apply (wp_rand_err_list_nat _ m (seq n (m - n))).
+    iSplitL "Hcr".
+    - (* yeesh *)
+      rewrite /err_factor.
+      replace (length (seq _ _)) with (m - n)%nat by (symmetry; apply seq_length).
+      replace (S m) with (m + 1)%nat by lia.
+      done.
+    - iIntros (sample'') "%Hsample''".
+      wp_pures.
+      case_bool_decide; wp_pures.
+      + iApply "HΦ". auto.
+      + exfalso; apply H1.
+        remember (sample'' <? n)%nat as P.
+        destruct P.
+        * apply inj_lt; apply Nat.ltb_lt; done.
+        * (* I don't know if that made it any easier lol *)
+          (* anyways, it's true, but I think the rand_err_list_nat needs to be strengthened
+             since we lost the fact that sample'' : fin (S m) along the way *)
+          admit.
+  Admitted.
+
+
+
+  Definition bdd_cf_approx_safe (n m depth: nat) (Hnm : n <= m) E :
+    {{{ € (bdd_cf_error n m depth Hnm) }}} bdd_cf_rejection_sampler n m #depth @ E {{{ v, RET v ; ⌜ v = SOMEV #() ⌝ }}}.
+  Proof.
+    iIntros (Φ) "Hcr HΦ"; rewrite /bdd_cf_rejection_sampler.
+    do 4 wp_pure.
+    (* invariant: (bdd_cf_error n m depth Hnm) *  ??? = ??? *)
+    iLöb as "IH".
+  Admitted.
+
+
+
+End proofs.
+

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -296,7 +296,7 @@ Section basic.
 
 
   Local Open Scope R.
-  Context `{!clutchGS Σ}.
+  Context `{!ub_clutchGS Σ}.
 
   (* In general:
       S n' = n
@@ -313,7 +313,7 @@ Section basic.
         (rec: "f" "tries_left" :=
            if: ("tries_left" - #1) < #0
             then NONE
-            else let: "next_sample" := (rand #m' from #()) in
+            else let: "next_sample" := (rand #m') in
                 if: ("next_sample" ≤ #n')
                 then SOME "next_sample"
                 else "f" ("tries_left" - #1))
@@ -325,7 +325,7 @@ Section basic.
     λ: "_",
       let: "do_sample" :=
         (rec: "f" "_" :=
-           let: "next_sample" := (rand #m' from #()) in
+           let: "next_sample" := (rand #m') in
            if: ("next_sample" ≤ #n')
             then SOME "next_sample"
             else "f" #())
@@ -863,7 +863,7 @@ End basic.
 Section higherorder.
   (* higher order rejection sampling *)
   Local Open Scope R.
-  Context `{!clutchGS Σ}.
+  Context `{!ub_clutchGS Σ}.
 
   (* spending error credits is proof irrelevant *)
   Lemma ec_spend_irrel a b : (nonneg b <= nonneg a) -> € a -∗ € b.
@@ -1006,8 +1006,12 @@ Section higherorder.
       + wp_pures.
         iApply "HΦ"; iModIntro; iPureIntro. exists sample; auto.
       +  iSpecialize ("IH" with "[Hcr]").
-        { iClear "#". rewrite /scale_unless. replace (Θ sample) with false.
-          rewrite simpl_generic_geometric_error; [iFrame | done].}
+        { iClear "#".
+          rewrite /scale_unless.
+          replace (Θ sample) with false.
+          rewrite simpl_generic_geometric_error.
+          - iFrame.
+          - done. }
         iSpecialize ("IH" with "HΦ").
         iClear "#".
         wp_pure.
@@ -1092,13 +1096,13 @@ End higherorder.
 Section higherorder_rand.
   (* higher order version of the basic rejection sampler *)
   Local Open Scope R.
-  Context `{!clutchGS Σ}.
+  Context `{!ub_clutchGS Σ}.
 
 
   (* next, we should show that this can actually be instantiated by some sane samplers *)
   Definition rand_sampling_scheme (n' m' : nat) (Hnm : (n' < m')%nat) : expr
      := (λ: "_", (Pair
-                    (λ: "_", rand #m' from #())
+                    (λ: "_", rand #m')
                     (λ: "sample", "sample" ≤ #n')))%E.
 
 
@@ -1271,7 +1275,7 @@ Section higherorder_rand.
 
   Lemma rand_sampling_scheme_spec_aggressive_ho (n' m' : nat) (Hnm : (n' < m')%nat) E :
     ⊢ sampling_scheme_spec_aggressive_ho
-          (λ: "_", rand #m' from #())%V
+          (λ: "_", rand #m')%V
           (λ: "sample", "sample" ≤ #n')%V
           (err_factor (S n') (S m'))
           (err_factor (S n') (S m'))
@@ -1354,11 +1358,11 @@ End higherorder_rand.
 Section higherorder_flip2.
   (* higher order version of a sampler which rejects until two coin flips are 1 *)
   Local Open Scope R.
-  Context `{!clutchGS Σ}.
+  Context `{!ub_clutchGS Σ}.
 
   Definition flip2_sampling_scheme : expr
      := (λ: "_",  (Pair
-                     (λ: "_", Pair (rand #1 from #()) (rand #1 from #()))
+                     (λ: "_", Pair (rand #1) (rand #1))
                      (λ: "sample", (((Fst "sample") = #1) && ((Snd "sample") = #1)))))%E.
 
 
@@ -1398,7 +1402,7 @@ Section higherorder_flip2.
    *)
   Lemma flip_amplification (𝜀1 𝜀h 𝜀t : nonnegreal) (Hmean : (𝜀h + 𝜀t) = 2 * 𝜀1 ) E :
     {{{ € 𝜀1 }}}
-      rand #1 from #() @ E
+      rand #1 @ E
     {{{ v, RET #v; ⌜(v = 0%nat) \/ (v = 1%nat) ⌝ ∗ € (scale_flip 𝜀1 𝜀h 𝜀t #v) }}}.
   Proof.
     iIntros (Φ) "Hcr HΦ".
@@ -1446,7 +1450,7 @@ Section higherorder_flip2.
     iSplit.
     { iIntros (𝜀1 post) "!> Hcr Hpost".
       wp_pures.
-      wp_bind (rand #1 from #())%E.
+      wp_bind (rand #1)%E.
       (* amplify: give 4/3 error to the false branch, and 2/3 error to the second *)
       wp_apply (flip_amplification 𝜀1
                   (nnreal_mult 𝜀1 (nnreal_div (nnreal_nat 2) (nnreal_nat 3)))
@@ -1456,7 +1460,7 @@ Section higherorder_flip2.
       iIntros (v) "(%Hv&Hcr)".
       destruct Hv as [-> | ->].
       - (* first flip was zero, second flip doesn't matter. *)
-        wp_bind (rand _ from #())%E; iApply wp_rand; auto.
+        wp_bind (rand _)%E; iApply wp_rand; auto.
         iNext; iIntros (v') "_"; wp_pures; iModIntro; iApply "Hpost".
         iSplitR.
         + rewrite /flip2_support.
@@ -1473,7 +1477,7 @@ Section higherorder_flip2.
           (𝜀1 * nnreal_div (nnreal_nat 2) (nnreal_nat 3))%NNR; last first.
         { rewrite /scale_flip /flip_is_1 /=. by apply nnreal_ext. }
         remember (𝜀1 * nnreal_div (nnreal_nat 2) (nnreal_nat 3))%NNR as 𝜀'.
-        wp_bind (rand #1 from #())%E.
+        wp_bind (rand #1 )%E.
         wp_apply (flip_amplification 𝜀' nnreal_zero (nnreal_mult 𝜀' (nnreal_nat 2)) with "Hcr").
         { simpl. lra. }
         iIntros (v) "(%Hv&Hcr)".
@@ -1533,7 +1537,7 @@ Section higherorder_flip2.
 
       iIntros (v close) "!> Hcr Hclose".
       wp_pures.
-      wp_bind (rand #1 from #())%E.
+      wp_bind (rand #1 )%E.
 
       (* give € 1 to the 0 flip, and € 1/2 to the 1 flip *)
       wp_apply (flip_amplification
@@ -1548,9 +1552,9 @@ Section higherorder_flip2.
         iAssert (▷ False)%I with "[Hcr]" as "Hspend".
         { iApply credit_spend_1. iApply (ec_spend_irrel with "Hcr").
           rewrite /scale_flip /flip_is_1 /=. lra. }
-        wp_bind (rand _ from _)%E; iApply wp_rand; auto.
+        wp_bind (rand _)%E; iApply wp_rand; auto.
       -  (* we have € 1/2 so we can make the second flip be 1 too *)
-        wp_bind (rand #1 from #())%E.
+        wp_bind (rand #1)%E.
         iApply (wp_rand_err _ _ 0%fin with "[Hcr Hclose]").
         iSplitL "Hcr". { iApply (ec_spend_irrel with "Hcr"). rewrite /=; lra. }
         iIntros (v') "%Hv'".
@@ -1562,9 +1566,9 @@ Section higherorder_flip2.
 
       { (* sampling support *)
         iIntros (close) "!> _ Hclose". wp_pures.
-        wp_bind (rand #1 from #())%E.
+        wp_bind (rand #1)%E.
         iApply wp_rand; auto; iNext; iIntros (v') "_".
-        wp_bind (rand #1 from #())%E.
+        wp_bind (rand #1 )%E.
         iApply wp_rand; auto; iNext; iIntros (v'') "_".
         wp_pures; iModIntro; iApply "Hclose"; iPureIntro.
         rewrite /flip2_support.
@@ -1579,7 +1583,7 @@ Section higherorder_flip2.
 
   Lemma flip2_sampling_scheme_spec_aggressive_ho E :
     ⊢ sampling_scheme_spec_aggressive_ho
-          (λ: "_", Pair (rand #1 from #()) (rand #1 from #()))
+          (λ: "_", Pair (rand #1) (rand #1))
           (λ: "sample", (((Fst "sample") = #1) && ((Snd "sample") = #1)))
           (nnreal_div (nnreal_nat 3%nat) (nnreal_nat 4%nat))
           (nnreal_div (nnreal_nat 3%nat) (nnreal_nat 4%nat))
@@ -1596,7 +1600,7 @@ Section higherorder_flip2.
       iIntros (v) "(%Hv&Hcr)".
       destruct Hv as [-> | ->].
       + (* first flip was zero, check is going to false and the second flip doesn't matter. *)
-        wp_bind (rand _ from #())%E; iApply wp_rand; auto.
+        wp_bind (rand _)%E; iApply wp_rand; auto.
         iNext; iIntros (v') "_"; wp_pures; iModIntro; iApply "HΦ".
         iRight; iExists _.
         iSplitL "Hcr"; [iFrame|].
@@ -1610,7 +1614,7 @@ Section higherorder_flip2.
         replace (scale_flip 𝜀 _ _ _) with (𝜀 * nnreal_div (nnreal_nat 2) (nnreal_nat 3))%NNR; last first.
         { rewrite /scale_flip /flip_is_1 /=. by apply nnreal_ext. }
         remember (𝜀 * nnreal_div (nnreal_nat 2) (nnreal_nat 3))%NNR as 𝜀'.
-        wp_bind (rand #1 from #())%E.
+        wp_bind (rand #1 )%E.
         wp_apply (flip_amplification 𝜀' nnreal_zero (nnreal_mult 𝜀' (nnreal_nat 2)) with "Hcr").
         { simpl. lra. }
         iIntros (v) "(%Hv&Hcr)".
@@ -1630,7 +1634,7 @@ Section higherorder_flip2.
 
     - (* credit spending rule *)
       iIntros (s Φ) "!> Hcr HΦ"; wp_pures.
-      wp_bind (rand #1 from #())%E.
+      wp_bind (rand #1)%E.
 
       (* give € 1 to the 0 flip, and € 1/2 to the 1 flip *)
       wp_apply (flip_amplification
@@ -1643,9 +1647,9 @@ Section higherorder_flip2.
         iAssert (▷ False)%I with "[Hcr]" as "Hspend".
         { iApply credit_spend_1. iApply (ec_spend_irrel with "Hcr").
           rewrite /scale_flip /flip_is_1 /=. lra. }
-        wp_bind (rand _ from _)%E; iApply wp_rand; try auto.
+        wp_bind (rand _)%E; iApply wp_rand; try auto.
       +  (* we have € 1/2 so we can make the second flip be 1 too *)
-        wp_bind (rand #1 from #())%E.
+        wp_bind (rand #1)%E.
         iApply (wp_rand_err _ _ 0%fin with "[Hcr HΦ]").
         iSplitL "Hcr". { iApply (ec_spend_irrel with "Hcr"). rewrite /=; lra. }
         iIntros (v') "%Hv'".

--- a/theories/examples/approximate_bounded_rejection_sampler.v
+++ b/theories/examples/approximate_bounded_rejection_sampler.v
@@ -246,23 +246,23 @@ Section basic.
 
     (* S depth=3 sample *)
     wp_apply (wp_couple_rand_adv_comp _ _ _ Φ _ (bdd_cf_sampling_error (S n') _ _) with "Hcr").
-    { apply sample_err_wf. }
+    { intros s. apply sample_err_wf; try lia. }
     { pose P := (sample_err_mean n' m' (bdd_cf_error (S n') (S m') 3)); apply P. }
     iIntros (sample) "Hcr".
     wp_pures.
     case_bool_decide; wp_pures.
     { iApply "HΦ"; iModIntro; iPureIntro; exists (fin_to_nat sample); split; [auto|lia]. }
-    rewrite (simplify_accum_err (S n') (S m') _); last (apply Nat.ltb_nlt; by lia).
+    rewrite (simplify_accum_err (S n') (S m') _); last (apply Nat.ltb_nlt; by lia); try lia.
 
     (* S depth=2 sample *)
     wp_apply (wp_couple_rand_adv_comp _ _ _ Φ _ (bdd_cf_sampling_error (S n') _ _) with "Hcr").
-    { apply sample_err_wf. }
+    { intros s. apply sample_err_wf; try lia. }
     { pose P := (sample_err_mean n' m' (bdd_cf_error (S n') (S m') 2)); apply P. }
     iIntros (sample') "Hcr".
     wp_pures.
     case_bool_decide; wp_pures.
     { iApply "HΦ"; iModIntro; iPureIntro; exists (fin_to_nat sample'); split; [auto|lia]. }
-    rewrite (simplify_accum_err (S n') (S m') _); last (apply Nat.ltb_nlt; by lia).
+    rewrite (simplify_accum_err (S n') (S m') _); last (apply Nat.ltb_nlt; by lia); try lia.
 
     (* S depth=1 sample *)
     rewrite bdd_cd_error_penultimate.
@@ -327,14 +327,14 @@ Section basic.
       replace (bool_decide _) with false; last (symmetry; apply bool_decide_eq_false; lia).
       wp_pures.
       wp_apply (wp_couple_rand_adv_comp _ _ _ Φ _ (bdd_cf_sampling_error (S n') _ _) with "Hcr").
-      { apply sample_err_wf. }
+      { intros s. apply sample_err_wf; try lia. }
       { pose P := (sample_err_mean n' m' (bdd_cf_error (S n') (S m') _)); rewrite Heqn Heqm; by eapply P. }
       iIntros (sample') "Hcr".
       wp_pures.
       case_bool_decide.
       + wp_pures; iApply "HΦ"; iModIntro; iPureIntro; exists (fin_to_nat sample'); split; [auto|lia].
       + wp_pure.
-        rewrite (simplify_accum_err (S n') (S m') _); last (apply Nat.ltb_nlt; by lia).
+        rewrite (simplify_accum_err (S n') (S m') _); last (apply Nat.ltb_nlt; by lia); try lia.
         wp_bind (#_ - #_)%E. wp_pure.
         replace (S (S depth') - 1)%Z with (Z.of_nat (S depth')) by lia.
         rewrite Heqn Heqm.
@@ -378,14 +378,14 @@ Section basic.
           specialize (fin_to_nat_lt sample''); by lia.
     - wp_pures.
       wp_apply (wp_couple_rand_adv_comp _ _ _ Φ _ (bdd_cf_sampling_error (S n') _ _) with "Hcr").
-      { apply sample_err_wf. }
+      { intros s. apply sample_err_wf; try lia. }
       { pose P := (sample_err_mean n' m' (bdd_cf_error (S n') (S m') _)); rewrite Heqn Heqm; by eapply P. }
       iIntros (sample') "Hcr".
       wp_pures.
       case_bool_decide.
       + wp_pures. iApply "HΦ"; iModIntro; iPureIntro; exists (fin_to_nat sample'); split; [auto|lia].
       + wp_pure.
-        rewrite (simplify_accum_err (S n') (S m') _); last (apply Nat.ltb_nlt; by lia).
+        rewrite (simplify_accum_err (S n') (S m') _); last (apply Nat.ltb_nlt; by lia); try lia.
         rewrite Heqn Heqm.
         wp_apply ("IH" with "Hcr HΦ").
   Qed.

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -802,6 +802,12 @@ Proof.
 Qed.
 
 
+
+
+Lemma ec_spend_le_irrel ε1 ε2 : (ε2.(nonneg) <= ε1.(nonneg))%R → € ε1 -∗ € ε2.
+Proof. iIntros (?) "?". iApply ec_weaken; done. Qed.
+
+
 Lemma ec_spend_irrel ε1 ε2 : (ε1.(nonneg) = ε2.(nonneg)) → € ε1 -∗ € ε2.
 Proof.
   iIntros (?) "?".

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -1074,14 +1074,14 @@ Qed.
 
 (* pads the junk up to a multiple of blocksize *)
 Definition block_pad N blocksize : list (fin (S (S N))) -> list (fin (S (S N))) :=
-  fun junk => repeat 0%fin (blocksize - (length junk mod blocksize))%nat.
+  fun junk => repeat 0%fin ((blocksize - (length junk mod blocksize)) mod blocksize)%nat.
 
 Lemma blocks_aligned N blocksize : (0 < blocksize) -> forall junk, (length junk + length (block_pad N blocksize junk)) mod blocksize = 0%nat.
 Proof.
   intros Hblocksize junk.
   rewrite /block_pad.
-  rewrite -Nat.Div0.add_mod_idemp_l.
   rewrite repeat_length.
+  rewrite -Nat.Div0.add_mod_idemp_l -PeanoNat.Nat.Div0.add_mod -Nat.Div0.add_mod_idemp_l.
   rewrite -Nat.le_add_sub; [apply Nat.Div0.mod_same|].
   edestruct Nat.mod_bound_pos as [? H]; last first.
   - eapply Nat.lt_le_incl, H.
@@ -1089,9 +1089,14 @@ Proof.
   - lia.
 Qed.
 
-Lemma block_pad_ub N blocksize : forall junk, (length (block_pad N blocksize junk) <= blocksize)%nat.
-Proof. intros. rewrite /block_pad repeat_length. apply Nat.le_sub_l. Qed.
-
+Lemma block_pad_ub N blocksize : (0 < blocksize) -> forall junk, (length (block_pad N blocksize junk) <= blocksize)%nat.
+Proof.
+  intros. rewrite /block_pad repeat_length.
+  edestruct Nat.mod_bound_pos; last first.
+  - eapply Nat.lt_le_incl, H1.
+  - lia.
+  - lia.
+Qed.
 
 
 (* version where junk is a mipltple of sample length *)
@@ -1114,6 +1119,7 @@ Proof.
       * rewrite app_length HS /=. lia.
       * rewrite app_length /=.
         apply Nat.add_le_mono_r, block_pad_ub.
+        rewrite HS /=. lia.
     + rewrite HS.
       (* iFrame is very slow here *)
       iFrame.

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -216,7 +216,7 @@ Qed.
 Lemma wp_rand_err_nat (N : nat) (z : Z) (m : nat) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_inv(nnreal_nat(N+1))) ∗
-  (∀ x, ⌜x ≠ m⌝ -∗ Φ #x)
+  (∀ x : fin (S N), ⌜(fin_to_nat x) ≠ m⌝ -∗ Φ #x)
   ⊢ WP rand #z @ E {{ Φ }}.
 Proof.
   iIntros (->) "[Herr Hwp]".
@@ -271,7 +271,7 @@ Qed.
 Lemma wp_rand_err_list_nat (N : nat) (z : Z) (ns : list nat) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_div (nnreal_nat (length ns)) (nnreal_nat(N+1))) ∗
-  (∀ x, ⌜Forall (λ m, x ≠ m) ns⌝ -∗ Φ #x)
+  (∀ x : fin (S N), ⌜Forall (λ m, (fin_to_nat x) ≠ m) ns⌝ -∗ Φ #x)
   ⊢ WP rand #z @ E {{ Φ }}.
 Proof.
   iIntros (->) "[Herr Hwp]".
@@ -326,7 +326,7 @@ Qed.
 Lemma wp_rand_err_list_int (N : nat) (z : Z) (zs : list Z) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_div (nnreal_nat (length zs)) (nnreal_nat(N+1))) ∗
-  (∀ x : Z , ⌜Forall (λ m, x ≠ m) zs⌝ -∗ Φ #x)
+  (∀ x : fin (S N), ⌜Forall (λ m, (Z.of_nat $ fin_to_nat x) ≠ m) zs⌝ -∗ Φ #x)
   ⊢ WP rand #z @ E {{ Φ }}.
 Proof.
   iIntros (->) "[Herr Hwp]".

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -572,6 +572,20 @@ Proof.
 Admitted.
 
 
+(* FIXME: merge with Hei Li's changes *)
+Lemma wp_couple_rand_adv_comp1 (N : nat) z E Φ (ε1 : nonnegreal) (ε2 : fin (S N) -> nonnegreal) :
+  TCEq N (Z.to_nat z) →
+  SeriesC (λ n, (1 / (S N)) * ε2 n)%R = (nonneg ε1) →
+  {{{ € ε1 }}} rand #z @ E {{{ n, RET #n; € (ε2 n) }}}.
+Proof.
+  iIntros (H1 H2).
+  eapply (wp_couple_rand_adv_comp _ _ _ Φ ε1 ε2).
+  - apply H1.
+  - edestruct mean_constraint_ub as [H3 H4].
+    + apply H2.
+    + eexists _; eapply H4.
+  - apply H2.
+Qed.
 
 (** * Approximate Lifting *)
 Lemma ub_lift_state (N : nat) 𝜎 𝛼 ns :

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -939,9 +939,9 @@ Proof.
   iIntros (? ? Hl) "(Hcr & Htape & Hwp)".
   destruct suffix as [|s0 sr].
   - iApply "Hwp". iLeft. rewrite -app_nil_end. iFrame.
-  - remember (s0 :: sr) as suffix.
+  - remember (s0 :: sr) as suffix'.
     assert (Hl_pos : (0 < L)%nat).
-    { rewrite Hl Heqsuffix cons_length. lia. }
+    { rewrite Hl Heqsuffix' cons_length. lia. }
     iApply (presample_amplify' with "[Htape Hcr]"); eauto; [iFrame|].
     iIntros "[H|(H&_)]"; iApply "Hwp".
     + iRight. by iFrame.
@@ -952,10 +952,10 @@ Qed.
 Lemma seq_amplify N z e E α Φ (ε : posreal) L (kwf: kwf N L) prefix suffix d :
   TCEq N (Z.to_nat z) →
   to_val e = None →
-  L = (length suffix) ->
+  (forall junk, 0 < (length (suffix (prefix ++ junk))) <= L)%nat ->
   € (pos_to_nn ε) ∗
   (α ↪ (N; prefix)) ∗
-  ((∃ junk, α ↪ (N; prefix ++ junk ++ suffix) ∨ α ↪ (N; prefix ++ junk) ∗ €(pos_to_nn (εAmp_iter N L d ε kwf)))
+  ((∃ junk, α ↪ (N; prefix ++ junk ++ (suffix (prefix ++ junk))) ∨ α ↪ (N; prefix ++ junk) ∗ €(pos_to_nn (εAmp_iter N L d ε kwf)))
    -∗ WP e @ E {{ Φ }})
   ⊢ WP e @ E {{ Φ }}.
 Proof.
@@ -968,29 +968,52 @@ Proof.
   - iApply ("IH" with "Hcr Htape").
     iIntros "[%junk [Hlucky|(Htape&Hcr)]]".
     + iApply "Hwp". iExists junk; iLeft; iFrame.
-    + iApply wp_presample_amplify; eauto; iFrame.
+    + pose L' := (length (suffix (prefix ++ junk))).
+      iApply (wp_presample_amplify _ _ _ _ _ _ _ L'); eauto; iFrame.
       iIntros "[?|[%junk' (Htape&Hcr)]]"; iApply "Hwp".
       * iExists _; iLeft.
         rewrite -app_assoc; iFrame.
       * iExists _; iRight.
         rewrite -app_assoc -εAmp_iter_cmp; iFrame.
+        iApply (ec_spend_le_irrel with "Hcr").
+        rewrite /εAmp /=.
+        apply Rmult_le_compat_l.
+        { apply Rmult_le_pos; [apply Rlt_le, cond_pos | apply pow_le, Rlt_le, k_pos]. }
+        apply Rplus_le_compat_l.
+        rewrite /Rdiv Rmult_1_l Rmult_1_l.
+        apply Rinv_le_contravar.
+        -- apply (Rplus_lt_reg_r 1%R).
+           rewrite /Rminus Rplus_assoc Rplus_opp_l Rplus_0_l Rplus_0_r.
+           apply Rlt_pow_R1.
+           --- apply lt_1_INR; destruct kwf; lia.
+           --- rewrite /L'. by destruct (HL junk).
+        -- apply Rplus_le_compat_r, Rle_pow.
+           --- rewrite S_INR. pose P := (pos_INR N); lra.
+           --- rewrite /L'. by destruct (HL junk).
+  Unshelve.
+    destruct kwf.
+    destruct (HL junk).
+    rewrite /L'.
+    constructor; try lia.
 Qed.
 
 
-Lemma presample_planner_pos N z e E α Φ (ε : nonnegreal) prefix suffix :
+Lemma presample_planner_pos N z e E α Φ (ε : nonnegreal) L prefix suffix :
   TCEq N (Z.to_nat z) →
   to_val e = None →
   (0 < N)%nat ->
-  (0 < (length suffix))%nat ->
+  (forall junk, 0 < (length (suffix (prefix ++ junk))) <= L)%nat ->
   (0 < ε)%R ->
   € ε ∗
   (α ↪ (N; prefix)) ∗
-  ((∃ junk, α ↪ (N; prefix ++ junk ++ suffix)) -∗ WP e @ E {{ Φ }})
+  ((∃ junk, α ↪ (N; prefix ++ junk ++ (suffix (prefix ++ junk)))) -∗ WP e @ E {{ Φ }})
   ⊢ WP e @ E {{ Φ }}.
 Proof.
   iIntros (? ? ? ? Hε) "(Hcr & Htape & Hwp)".
-  remember (length suffix) as L.
-  assert (kwf : kwf N L). { apply mk_kwf; lia. }
+  assert (kwf : kwf N L). {
+    apply mk_kwf; try lia.
+    destruct (H2 []) as [H2' H2''].
+    eapply Nat.lt_le_trans; eauto. }
   pose ε' := mkposreal ε.(nonneg) Hε.
   replace ε with (pos_to_nn ε'); last first.
   { rewrite /ε' /pos_to_nn. by apply nnreal_ext. }
@@ -1004,6 +1027,31 @@ Proof.
     done.
 Qed.
 
+
+(* general planner rule, with bounded synchronization strings *)
+Lemma presample_planner_sync N z e E α Φ (ε : nonnegreal) L prefix suffix :
+  TCEq N (Z.to_nat z) →
+  to_val e = None →
+  (0 < ε)%R ->
+  (forall junk, 0 < (length (suffix (prefix ++ junk))) <= L)%nat ->
+  € ε ∗
+  (α ↪ (S N; prefix)) ∗
+  ((∃ junk, α ↪ (S N; prefix ++ junk ++ suffix (prefix ++ junk))) -∗ WP e @ E {{ Φ }})
+  ⊢ WP e @ E {{ Φ }}.
+Proof.
+  iIntros (? ? ? ?).
+  destruct (suffix prefix) as [|h R] eqn:Hsp.
+  - iIntros "(_ & Htape & Hwp)".
+    iApply "Hwp".
+    iExists [].
+    rewrite app_nil_r app_assoc app_nil_r Hsp app_nil_r.
+    iFrame.
+  - iApply (presample_planner_pos); eauto; try lia.
+    by erewrite Nat2Z.id.
+Qed.
+
+
+(* classic version *)
 Lemma presample_planner N z e E α Φ (ε : nonnegreal) prefix suffix :
   TCEq N (Z.to_nat z) →
   to_val e = None →
@@ -1013,16 +1061,64 @@ Lemma presample_planner N z e E α Φ (ε : nonnegreal) prefix suffix :
   ((∃ junk, α ↪ (S N; prefix ++ junk ++ suffix)) -∗ WP e @ E {{ Φ }})
   ⊢ WP e @ E {{ Φ }}.
 Proof.
-  iIntros (? ? ?).
-  destruct suffix as [|h R].
-  - iIntros "(_ & Htape & Hwp)".
-    iApply "Hwp".
+  iIntros (? ? ?) "(Hcr&Htape&Hwp)".
+  destruct suffix as [|] eqn:HS.
+  - iApply "Hwp".
     iExists [].
-    do 2 (rewrite -app_nil_end); iFrame.
-  - remember (h :: R) as suffix.
-    iApply (presample_planner_pos); eauto; try lia.
-    + by erewrite Nat2Z.id.
-    + rewrite Heqsuffix cons_length; lia.
+    do 2 rewrite app_nil_r; iFrame.
+  - iApply (presample_planner_sync _ _ _ _ _ _ _ (length suffix) _ (fun _ => suffix)); eauto.
+    + intros; rewrite HS /=. lia.
+    + rewrite HS. iFrame.
 Qed.
+
+
+(* pads the junk up to a multiple of blocksize *)
+Definition block_pad N blocksize : list (fin (S (S N))) -> list (fin (S (S N))) :=
+  fun junk => repeat 0%fin (blocksize - (length junk mod blocksize))%nat.
+
+Lemma blocks_aligned N blocksize : (0 < blocksize) -> forall junk, (length junk + length (block_pad N blocksize junk)) mod blocksize = 0%nat.
+Proof.
+  intros Hblocksize junk.
+  rewrite /block_pad.
+  rewrite -Nat.Div0.add_mod_idemp_l.
+  rewrite repeat_length.
+  rewrite -Nat.le_add_sub; [apply Nat.Div0.mod_same|].
+  edestruct Nat.mod_bound_pos as [? H]; last first.
+  - eapply Nat.lt_le_incl, H.
+  - lia.
+  - lia.
+Qed.
+
+Lemma block_pad_ub N blocksize : forall junk, (length (block_pad N blocksize junk) <= blocksize)%nat.
+Proof. intros. rewrite /block_pad repeat_length. apply Nat.le_sub_l. Qed.
+
+
+
+(* version where junk is a mipltple of sample length *)
+Lemma presample_planner_aligned N z e E α Φ (ε : nonnegreal) prefix suffix :
+  TCEq N (Z.to_nat z) →
+  to_val e = None →
+  (0 < ε)%R ->
+  € ε ∗
+  (α ↪ (S N; prefix)) ∗
+  ((∃ junk, α ↪ (S N; prefix ++ junk ++ (block_pad N (length suffix) (prefix ++ junk)) ++ suffix)) -∗ WP e @ E {{ Φ }})
+  ⊢ WP e @ E {{ Φ }}.
+Proof.
+  iIntros (? ? ?) "(Hcr&Htape&Hwp)".
+  destruct suffix as [|] eqn:HS.
+  - iApply "Hwp".
+    iExists [].
+    do 2 rewrite app_nil_r; iFrame.
+  - iApply (presample_planner_sync _ _ _ _ _ _ _ (length suffix + length suffix) _ (fun samples => block_pad N (length suffix) samples ++ suffix)); eauto.
+    + intros. split.
+      * rewrite app_length HS /=. lia.
+      * rewrite app_length /=.
+        apply Nat.add_le_mono_r, block_pad_ub.
+    + rewrite HS.
+      (* iFrame is very slow here *)
+      iFrame.
+Qed.
+
+
 
 End rules.


### PR DESCRIPTION
This PR is a work in progress

Implemented: 
- bounded and unbounded rejection sampler for `rand` "by hand"
- bounded and unbounded rejection sampler from the higher-order spec
- instance of the higher order spec for `rand` and `flip2`
- unbounded rejection sampler using the planner rule for `flip2`