### PR TITLE
Twp

### DIFF
--- a/theories/app_rel_logic/adequacy.v
+++ b/theories/app_rel_logic/adequacy.v
@@ -337,3 +337,22 @@ Proof.
     apply upper_bound_ge_sup.
     intro; simpl. auto.
 Qed.
+
+Theorem wp_ARcoupl_epsilon_lim Σ `{app_clutchGpreS Σ} (e e' : expr) (σ σ' : state) (ε : nonnegreal) φ :
+  (∀ `{app_clutchGS Σ} (ε' : nonnegreal), ε<ε' -> ⊢ spec_ctx -∗ ⤇ e' -∗ € ε' -∗ WP e {{ v, ∃ v', ⤇ Val v' ∗ ⌜φ v v'⌝ }} ) →
+  ARcoupl (lim_exec (e, σ)) (lim_exec (e', σ')) φ ε.
+Proof.
+  intros H'.
+  apply ARcoupl_limit.
+  intros ε' Hineq.
+  assert (0<=ε') as Hε'.
+  { trans ε; try lra. by destruct ε. }
+  pose (mknonnegreal ε' Hε') as NNRε'.
+  assert (ε' = (NNRbar_to_real (NNRbar.Finite NNRε'))) as Heq.
+  { by simpl. }
+  rewrite Heq.
+  eapply wp_aRcoupl_lim; first done.
+  intros. iIntros "Hctx".
+  iApply (H' with "[$Hctx]").
+  lra.
+Qed. 

--- a/theories/bi/weakestpre.v
+++ b/theories/bi/weakestpre.v
@@ -19,6 +19,15 @@ Global Arguments wp {_ _ _ _ _} _ _ _%E _%I.
 Global Instance: Params (@wp) 9 := {}.
 Global Arguments wp_default : simpl never.
 
+Class Twp (PROP EXPR VAL A : Type) := {
+    twp : A → coPset → EXPR → (VAL → PROP) → PROP;
+    twp_default : A
+    }.
+Global Arguments twp {_ _ _ _ _} _ _ _%E _%I.
+Global Instance: Params (@twp) 9 := {}.
+Global Arguments twp_default : simpl never.
+
+
 (** Notations for partial weakest preconditions *)
 (** Notations without binder -- only parsing because they overlap with the
 notations with binder. *)
@@ -176,3 +185,70 @@ Notation "'⟨⟨⟨' P ⟩ ⟩ ⟩ e @ E ⟨⟨⟨ 'RET' pat ; Q ⟩ ⟩ ⟩" :
   (∀ Φ, P -∗ (Q -∗ Φ pat%V) -∗ WP e @ E {{ Φ }}) : stdpp_scope.
 Notation "'⟨⟨⟨' P ⟩ ⟩ ⟩ e ⟨⟨⟨ 'RET' pat ; Q ⟩ ⟩ ⟩" :=
   (∀ Φ, P -∗ (Q -∗ Φ pat%V) -∗ WP e {{ Φ }}) : stdpp_scope.
+
+
+
+(** Notations for total weakest preconditions *)
+(** Notations without binder -- only parsing because they overlap with the
+notations with binder. *)
+Notation "'WP' e @ s ; E [{ Φ } ]" := (twp s E e%E Φ)
+  (at level 20, e, Φ at level 200, only parsing) : bi_scope.
+Notation "'WP' e @ E [{ Φ } ]" := (twp wp_default E e%E Φ)
+  (at level 20, e, Φ at level 200, only parsing) : bi_scope.
+Notation "'WP' e [{ Φ } ]" := (twp wp_default ⊤ e%E Φ)
+  (at level 20, e, Φ at level 200, only parsing) : bi_scope.
+
+(** Notations with binder. *)
+Notation "'WP' e @ s ; E [{ v , Q } ]" := (twp s E e%E (λ v, Q))
+  (at level 20, e, Q at level 200,
+   format "'[hv' 'WP'  e  '/' @  '[' s ;  '/' E  ']' '/' [{  '[' v ,  '/' Q  ']' } ] ']'") : bi_scope.
+Notation "'WP' e @ E [{ v , Q } ]" := (twp twp_default E e%E (λ v, Q))
+  (at level 20, e, Q at level 200,
+   format "'[hv' 'WP'  e  '/' @  E  '/' [{  '[' v ,  '/' Q  ']' } ] ']'") : bi_scope.
+Notation "'WP' e [{ v , Q } ]" := (twp twp_default ⊤ e%E (λ v, Q))
+  (at level 20, e, Q at level 200,
+   format "'[hv' 'WP'  e  '/' [{  '[' v ,  '/' Q  ']' } ] ']'") : bi_scope.
+
+(* Texan triples *)
+Notation "'[[{' P } ] ] e @ s ; E [[{ x .. y , 'RET' pat ; Q } ] ]" :=
+  (□ ∀ Φ,
+      P -∗ (∀ x, .. (∀ y, Q -∗ Φ pat%V) .. ) -∗ WP e @ s; E [{ Φ }])%I
+    (at level 20, x closed binder, y closed binder,
+     format "'[hv' [[{  '[' P  ']' } ] ]  '/  ' e  '/' @  '[' s ;  '/' E  ']' '/' [[{  '[hv' x  ..  y ,  RET  pat ;  '/' Q  ']' } ] ] ']'") : bi_scope.
+Notation "'[[{' P } ] ] e @ E [[{ x .. y , 'RET' pat ; Q } ] ]" :=
+  (□ ∀ Φ,
+      P -∗ (∀ x, .. (∀ y, Q -∗ Φ pat%V) .. ) -∗ WP e @ E [{ Φ }])%I
+    (at level 20, x closed binder, y closed binder,
+     format "'[hv' [[{  '[' P  ']' } ] ]  '/  ' e  '/' @  E  '/' [[{  '[hv' x  ..  y ,  RET  pat ;  '/' Q  ']' } ] ] ']'") : bi_scope.
+Notation "'[[{' P } ] ] e [[{ x .. y , 'RET' pat ; Q } ] ]" :=
+  (□ ∀ Φ,
+      P -∗ (∀ x, .. (∀ y, Q -∗ Φ pat%V) .. ) -∗ WP e [{ Φ }])%I
+    (at level 20, x closed binder, y closed binder,
+       format "'[hv' [[{  '[' P  ']' } ] ]  '/  ' e  '/' [[{  '[hv' x  ..  y ,  RET  pat ;  '/' Q  ']' } ] ] ']'") : bi_scope.
+
+Notation "'[[{' P } ] ] e @ s ; E [[{ 'RET' pat ; Q } ] ]" :=
+  (□ ∀ Φ, P -∗ (Q -∗ Φ pat%V) -∗ WP e @ s; E [{ Φ }])%I
+    (at level 20,
+     format "'[hv' [[{  '[' P  ']' } ] ]  '/  ' e  '/' @  '[' s ;  '/' E  ']' '/' [[{  '[hv' RET  pat ;  '/' Q  ']' } ] ] ']'") : bi_scope.
+Notation "'[[{' P } ] ] e @ E [[{ 'RET' pat ; Q } ] ]" :=
+  (□ ∀ Φ, P -∗ (Q -∗ Φ pat%V) -∗ WP e @ E [{ Φ }])%I
+    (at level 20,
+     format "'[hv' [[{  '[' P  ']' } ] ]  '/  ' e  '/' @  E  '/' [[{  '[hv' RET  pat ;  '/' Q  ']' } ] ] ']'") : bi_scope.
+Notation "'[[{' P } ] ] e [[{ 'RET' pat ; Q } ] ]" :=
+  (□ ∀ Φ, P -∗ (Q -∗ Φ pat%V) -∗ WP e [{ Φ }])%I
+    (at level 20,
+     format "'[hv' [[{  '[' P  ']' } ] ]  '/  ' e  '/' [[{  '[hv' RET  pat ;  '/' Q  ']' } ] ] ']'") : bi_scope.
+
+(** Aliases for stdpp scope -- they inherit the levels and format from above. *)
+Notation "'[[{' P } ] ] e @ s ; E [[{ x .. y , 'RET' pat ; Q } ] ]" :=
+  (∀ Φ, P -∗ (∀ x, .. (∀ y, Q -∗ Φ pat%V) .. ) -∗ WP e @ s; E [{ Φ }]) : stdpp_scope.
+Notation "'[[{' P } ] ] e @ E [[{ x .. y , 'RET' pat ; Q } ] ]" :=
+  (∀ Φ, P -∗ (∀ x, .. (∀ y, Q -∗ Φ pat%V) .. ) -∗ WP e @ E [{ Φ }]) : stdpp_scope.
+Notation "'[[{' P } ] ] e [[{ x .. y , 'RET' pat ; Q } ] ]" :=
+  (∀ Φ, P -∗ (∀ x, .. (∀ y, Q -∗ Φ pat%V) .. ) -∗ WP e [{ Φ }]) : stdpp_scope.
+Notation "'[[{' P } ] ] e @ s ; E [[{ 'RET' pat ; Q } ] ]" :=
+  (∀ Φ, P -∗ (Q -∗ Φ pat%V) -∗ WP e @ s; E [{ Φ }]) : stdpp_scope.
+Notation "'[[{' P } ] ] e @ E [[{ 'RET' pat ; Q } ] ]" :=
+  (∀ Φ, P -∗ (Q -∗ Φ pat%V) -∗ WP e @ E [{ Φ }]) : stdpp_scope.
+Notation "'[[{' P } ] ] e [[{ 'RET' pat ; Q } ] ]" :=
+  (∀ Φ, P -∗ (Q -∗ Φ pat%V) -∗ WP e [{ Φ }]) : stdpp_scope. 

--- a/theories/bi/weakestpre.v
+++ b/theories/bi/weakestpre.v
@@ -193,9 +193,9 @@ Notation "'⟨⟨⟨' P ⟩ ⟩ ⟩ e ⟨⟨⟨ 'RET' pat ; Q ⟩ ⟩ ⟩" :=
 notations with binder. *)
 Notation "'WP' e @ s ; E [{ Φ } ]" := (twp s E e%E Φ)
   (at level 20, e, Φ at level 200, only parsing) : bi_scope.
-Notation "'WP' e @ E [{ Φ } ]" := (twp wp_default E e%E Φ)
+Notation "'WP' e @ E [{ Φ } ]" := (twp twp_default E e%E Φ)
   (at level 20, e, Φ at level 200, only parsing) : bi_scope.
-Notation "'WP' e [{ Φ } ]" := (twp wp_default ⊤ e%E Φ)
+Notation "'WP' e [{ Φ } ]" := (twp twp_default ⊤ e%E Φ)
   (at level 20, e, Φ at level 200, only parsing) : bi_scope.
 
 (** Notations with binder. *)

--- a/theories/prob/couplings_app.v
+++ b/theories/prob/couplings_app.v
@@ -953,6 +953,18 @@ Qed.
     intros ; by eapply ARcoupl_refRcoupl, Rcoupl_refRcoupl.
   Qed.
 
+  Lemma ARcoupl_limit `{Countable A, Countable B} μ1 μ2 ε (ψ : A -> B -> Prop):
+    (forall ε', ε' > ε -> ARcoupl μ1 μ2 ψ ε') -> ARcoupl μ1 μ2 ψ ε.
+  Proof.
+    rewrite /ARcoupl.
+    intros Hlimit. intros.
+    apply real_le_limit.
+    intros. rewrite Rle_minus_l.
+    rewrite Rplus_assoc.
+    apply Hlimit; try done.
+    lra.
+  Qed.
+
 (* Lemma Rcoupl_fair_conv_comb `{Countable A, Countable B} *)
 (*   f `{Inj bool bool (=) (=) f, Surj bool bool (=) f} *)
 (*   (S : A → B → Prop) (μ1 μ2 : distr A) (μ1' μ2' : distr B) : *)

--- a/theories/prob/union_bounds.v
+++ b/theories/prob/union_bounds.v
@@ -393,7 +393,17 @@ Proof.
   by apply HP, Hequiv.
 Qed.
 
-
+Lemma ub_lift_epsilon_limit `{Eq: EqDecision A} (μ : distr A) f ε':
+  ε'>=0 -> (forall ε, ε>ε' -> ub_lift μ f ε) -> ub_lift μ f ε'.
+Proof.
+  rewrite /ub_lift.
+  intros Hε' H'.
+  intros. apply real_le_limit.
+  intros ε Hε.
+  rewrite Rle_minus_l.
+  apply H'; first lra.
+  done.
+Qed.
 
 End ub_theory.
 

--- a/theories/prob/union_bounds.v
+++ b/theories/prob/union_bounds.v
@@ -600,6 +600,22 @@ Section total_ub_theory.
     - by apply Htotal. 
   Qed. 
 
+  Lemma total_ub_lift_implies_ub_lift_strong (μ : distr A) f ε:
+    total_ub_lift μ f ε -> ub_lift μ f (ε - (1 - SeriesC μ)).
+  Proof.
+    rewrite /total_ub_lift /ub_lift /prob.
+    intros Htotal P HP.
+    rewrite (SeriesC_ext _ (λ a, if P a then 0 else μ a)); last first.
+    { intros. by destruct (P n). }
+    eapply Rplus_le_reg_l.
+    rewrite <-SeriesC_split_pred; last first.
+    { apply pmf_ex_seriesC. }
+    { intros. apply pmf_pos. }
+    apply Rle_minus_l.
+    trans (1-ε).
+    - pose proof (pmf_SeriesC μ). lra.
+    - by apply Htotal. 
+  Qed. 
 
   
   Lemma total_UB_mon_grading (μ : distr A) (f : A -> Prop) ε ε' :

--- a/theories/prob/union_bounds.v
+++ b/theories/prob/union_bounds.v
@@ -912,4 +912,16 @@ Section total_ub_theory.
     done.
   Qed.
 
+  Lemma total_ub_lift_termination_ineq (μ : distr A) f ε:
+    total_ub_lift μ f ε -> 1 - ε <= SeriesC μ.
+  Proof.
+    intros H2.
+    assert (∀ x, Decision (f x)).
+    { intros. apply make_decision. }
+    trans (prob μ (λ x, bool_decide (f x))).
+    - apply H2. intros. by apply bool_decide_eq_true_2.
+    - apply SeriesC_le; last apply pmf_ex_seriesC.
+      intros n; case_bool_decide; pose proof (pmf_pos (μ) n); lra. 
+  Qed.
+  
 End total_ub_theory.

--- a/theories/ub_logic/adequacy.v
+++ b/theories/ub_logic/adequacy.v
@@ -249,3 +249,23 @@ Proof.
   intro n.
   apply (wp_union_bound Σ); auto.
 Qed.
+
+Theorem wp_union_bound_epsilon_lim Σ `{ub_clutchGpreS Σ} (e : expr) (σ : state) (ε : nonnegreal) φ :
+  (∀ `{ub_clutchGS Σ} (ε':nonnegreal), ε<ε' -> ⊢ € ε' -∗ WP e {{ v, ⌜φ v⌝ }}) →
+  ub_lift (lim_exec (e, σ)) φ ε.
+Proof.
+  intros H'.
+  apply ub_lift_epsilon_limit.
+  { destruct ε. simpl. lra. }
+  intros ε0 H1.
+  assert (0<=ε0) as Hε0.
+  { trans ε; try lra. by destruct ε. }
+  pose (mknonnegreal ε0 Hε0) as NNRε0.
+  assert (ε0 = (NNRbar_to_real (NNRbar.Finite (NNRε0)))) as Heq.
+  { by simpl. }
+  rewrite Heq.
+  eapply wp_union_bound_lim; first done.
+  intros. iIntros "He".
+  iApply H'; try iFrame.
+  simpl. destruct ε; simpl in H1; simpl; lra.
+Qed.

--- a/theories/ub_logic/cf_hash.v
+++ b/theories/ub_logic/cf_hash.v
@@ -366,7 +366,6 @@ Module coll_free_hash.
       + iSplit.
         * iPureIntro.
           rewrite mult_INR.
-          Search Rlt.
           rewrite <- (Rmult_1_l rval) at 1.
           apply Rmult_lt_compat_r.
           -- eapply Rle_lt_trans; eauto.

--- a/theories/ub_logic/lifting.v
+++ b/theories/ub_logic/lifting.v
@@ -147,10 +147,10 @@ Qed.
 Lemma wp_lift_atomic_step {E Φ} e1 :
   to_val e1 = None →
   (∀ σ1, state_interp σ1 ={E}=∗
-    ⌜reducible e1 σ1⌝ ∗
-    ▷ ∀ e2 σ2, ⌜prim_step e1 σ1 (e2, σ2) > 0⌝ ={E}=∗
-      state_interp σ2 ∗
-      from_option Φ False (to_val e2))
+         ⌜reducible e1 σ1⌝ ∗
+         ▷ ∀ e2 σ2, ⌜prim_step e1 σ1 (e2, σ2) > 0⌝ ={E}=∗
+                    state_interp σ2 ∗
+                    from_option Φ False (to_val e2))
   ⊢ WP e1 @ E {{ Φ }}.
 Proof.
   iIntros (?) "H". iApply wp_lift_atomic_step_fupd; [done|].

--- a/theories/ub_logic/proofmode.v
+++ b/theories/ub_logic/proofmode.v
@@ -6,6 +6,7 @@ From iris.program_logic Require Import atomic.
 From clutch.common Require Import language ectx_language.
 From clutch.prob_lang Require Import lang notation class_instances tactics.
 From clutch.ub_logic Require Import ub_weakestpre primitive_laws.
+From clutch.ub_logic Require Import ub_total_weakestpre total_primitive_laws.
 From iris.prelude Require Import options.
 Import uPred.
 

--- a/theories/ub_logic/proofmode.v
+++ b/theories/ub_logic/proofmode.v
@@ -65,10 +65,18 @@ Qed.
 Lemma tac_wp_value_nofupd `{!ub_clutchGS Σ} Δ E Φ v :
   envs_entails Δ (Φ v) → envs_entails Δ (WP (Val v) @ E {{ Φ }}).
 Proof. rewrite envs_entails_unseal=> ->. by apply ub_wp_value. Qed.
+Lemma tac_twp_value_nofupd `{!ub_clutchGS Σ} Δ s E Φ v :
+  envs_entails Δ (Φ v) → envs_entails Δ (WP (Val v) @ s; E [{ Φ }]).
+Proof. rewrite envs_entails_unseal=> ->. by apply ub_twp_value. Qed.
+
 
 Lemma tac_wp_value `{!ub_clutchGS Σ} Δ E (Φ : val → iPropI Σ) v :
   envs_entails Δ (|={E}=> Φ v) → envs_entails Δ (WP (Val v) @ E {{ Φ }}).
 Proof. rewrite envs_entails_unseal=> ->. by rewrite ub_wp_value_fupd. Qed.
+Lemma tac_twp_value `{!ub_clutchGS Σ} Δ s E (Φ : val → iPropI Σ) v :
+  envs_entails Δ (|={E}=> Φ v) → envs_entails Δ (WP (Val v) @ s; E [{ Φ }]).
+Proof. rewrite envs_entails_unseal=> ->. by rewrite ub_twp_value_fupd. Qed.
+
 
 (** Simplify the goal if it is [WP] of a value.
   If the postcondition already allows a fupd, do not add a second one.
@@ -81,7 +89,13 @@ Ltac wp_value_head :=
   | |- envs_entails _ (wp ?s ?E (Val _) (λ _, wp _ ?E _ _)) =>
       eapply tac_wp_value_nofupd
   | |- envs_entails _ (wp ?s ?E (Val _) _) =>
-      eapply tac_wp_value
+      eapply tac_wp_value             
+  | |- envs_entails _ (twp ?s ?E (Val _) (λ _, fupd ?E _ _)) =>
+      eapply tac_twp_value_nofupd
+  | |- envs_entails _ (twp ?s ?E (Val _) (λ _, twp _ ?E _ _)) =>
+      eapply tac_twp_value_nofupd
+  | |- envs_entails _ (twp ?s ?E (Val _) _) =>
+      eapply tac_twp_value
   end.
 
 Ltac wp_finish :=
@@ -203,12 +217,24 @@ Lemma tac_wp_bind `{!ub_clutchGS Σ} K Δ E Φ e f :
   envs_entails Δ (WP e @ E {{ v, WP f (Val v) @ E {{ Φ }} }})%I →
   envs_entails Δ (WP fill K e @ E {{ Φ }}).
 Proof. rewrite envs_entails_unseal=> -> ->. by apply: ub_wp_bind. Qed.
+Lemma tac_twp_bind `{!ub_clutchGS Σ} K Δ s E Φ e f :
+  f = (λ e, fill K e) → (* as an eta expanded hypothesis so that we can `simpl` it *)
+  envs_entails Δ (WP e @ s; E [{ v, WP f (Val v) @ s; E [{ Φ }] }])%I →
+  envs_entails Δ (WP fill K e @ s; E [{ Φ }]).
+Proof. rewrite envs_entails_unseal=> -> ->. by apply: ub_twp_bind. Qed.
+
 
 Ltac wp_bind_core K :=
   lazymatch eval hnf in K with
   | [] => idtac
   | _ => eapply (tac_wp_bind K); [simpl; reflexivity|reduction.pm_prettify]
   end.
+Ltac twp_bind_core K :=
+  lazymatch eval hnf in K with
+  | [] => idtac
+  | _ => eapply (tac_twp_bind K); [simpl; reflexivity|reduction.pm_prettify]
+  end.
+
 
 Tactic Notation "wp_bind" open_constr(efoc) :=
   iStartProof;
@@ -216,6 +242,10 @@ Tactic Notation "wp_bind" open_constr(efoc) :=
   | |- envs_entails _ (wp ?s ?E ?e ?Q) =>
     first [ reshape_expr e ltac:(fun K e' => unify e' efoc; wp_bind_core K)
           | fail 1 "wp_bind: cannot find" efoc "in" e ]
+  | |- envs_entails _ (twp ?s ?E ?e ?Q) =>
+    first [ reshape_expr e ltac:(fun K e' => unify e' efoc; twp_bind_core K)
+          | fail 1 "wp_bind: cannot find" efoc "in" e ]
+
   | _ => fail "wp_bind: not a 'wp'"
   end.
 
@@ -250,6 +280,26 @@ Proof.
   rewrite wand_elim_r.
   done.
 Qed.
+Lemma tac_twp_alloc Δ E j K v Φ :
+  (∀ l,
+    match envs_app false (Esnoc Enil j (l ↦ v)) Δ with
+    | Some Δ' =>
+       envs_entails Δ' (WP fill K (Val $ LitV $ l) @ E [{ Φ }])
+    | None => False
+    end) →
+  envs_entails Δ (WP fill K (Alloc (Val v)) @ E [{ Φ }]).
+Proof.
+  rewrite envs_entails_unseal=> HΔ.
+  rewrite -ub_twp_bind. eapply wand_apply; first apply wand_entails.
+  { iIntros "P Q". iApply (twp_alloc with "[P][Q]"); done. }
+  rewrite left_id. apply forall_intro=> l.
+  specialize (HΔ l).
+  destruct (envs_app _ _ _) as [Δ'|] eqn:HΔ'; [ | contradiction ].
+  rewrite envs_app_sound //; simpl.
+  apply wand_intro_l.
+  iIntros "[?T]". iApply HΔ. iApply "T". iFrame. 
+Qed.
+
 
 Lemma tac_wp_load Δ Δ' E i K b l q v Φ :
   MaybeIntoLaterNEnvs 1 Δ Δ' →
@@ -265,6 +315,19 @@ Proof.
   * iIntros "[#$ He]". iIntros "_". iApply Hi. iApply "He". iFrame "#".
   * by apply sep_mono_r, wand_mono.
 Qed.
+Lemma tac_twp_load Δ E i K b l q v Φ :
+  envs_lookup i Δ = Some (b, l ↦{q} v)%I →
+  envs_entails Δ (WP fill K (Val v) @ E [{ Φ }]) →
+  envs_entails Δ (WP fill K (Load (LitV l)) @ E [{ Φ }]).
+Proof.
+  rewrite envs_entails_unseal=> ? Hi.
+  rewrite -ub_twp_bind. eapply wand_apply; first exact: twp_load.
+  rewrite envs_lookup_split //; simpl.
+  destruct b; simpl.
+  - iIntros "[#$ He]". iIntros "_". iApply Hi. iApply "He". iFrame "#".
+  - iIntros "[$ He]". iIntros "Hl". iApply Hi. iApply "He". iFrame "Hl".
+Qed.
+
 
 Lemma tac_wp_store Δ Δ' E i K l v v' Φ :
   MaybeIntoLaterNEnvs 1 Δ Δ' →
@@ -281,6 +344,23 @@ Proof.
   rewrite into_laterN_env_sound -later_sep envs_simple_replace_sound //; simpl.
   rewrite right_id. by apply later_mono, sep_mono_r, wand_mono.
 Qed.
+Lemma tac_twp_store Δ E i K l v v' Φ :
+  envs_lookup i Δ = Some (false, l ↦ v)%I →
+  match envs_simple_replace i false (Esnoc Enil i (l ↦ v')) Δ with
+  | Some Δ' => envs_entails Δ' (WP fill K (Val $ LitV LitUnit) @ E [{ Φ }])
+  | None => False
+  end →
+  envs_entails Δ (WP fill K (Store (LitV l) v') @ E [{ Φ }]).
+Proof.
+  rewrite envs_entails_unseal. intros.
+  destruct (envs_simple_replace _ _ _) as [Δ''|] eqn:HΔ''; [ | contradiction ].
+  rewrite -ub_twp_bind. eapply wand_apply; first by eapply twp_store.
+  rewrite envs_simple_replace_sound //; simpl.
+  rewrite right_id. 
+  iIntros "[H?]". iSplitL "H"; first done.
+  by iApply wand_mono.
+Qed.
+
 End heap.
 
 (** The tactic [wp_apply_core lem tac_suc tac_fail] evaluates [lem] to a
@@ -301,6 +381,10 @@ Ltac wp_apply_core lem tac_suc tac_fail := first
      | |- envs_entails _ (wp ?s ?E ?e ?Q) =>
        reshape_expr e ltac:(fun K e' =>
          wp_bind_core K; tac_suc H)
+     | |- envs_entails _ (twp ?s ?E ?e ?Q) =>
+       reshape_expr e ltac:(fun K e' =>
+         twp_bind_core K; tac_suc H)
+
      | _ => fail 1 "wp_apply: not a 'wp'"
      end)
   |tac_fail ltac:(fun _ => wp_apply_core lem tac_suc tac_fail)
@@ -360,6 +444,13 @@ Tactic Notation "wp_alloc" ident(l) "as" constr(H) :=
         [iSolveTC
         |finish ()]
     in (process_single ())
+  | |- envs_entails _ (twp ?s ?E ?e ?Q) =>
+    let process_single _ :=
+        first
+          [reshape_expr e ltac:(fun K e' => eapply (tac_twp_alloc _ _ _ Htmp K))
+          |fail 1 "wp_alloc: cannot find 'Alloc' in" e];
+        finish ()
+    in process_single ()
   | _ => fail "wp_alloc: not a 'wp'"
   end.
 
@@ -379,6 +470,12 @@ Tactic Notation "wp_load" :=
     [iSolveTC
     |solve_mapsto ()
     |wp_finish]
+  | |- envs_entails _ (twp ?s ?E ?e ?Q) =>
+    first
+      [reshape_expr e ltac:(fun K e' => eapply (tac_twp_load _ _ _ _ K))
+      |fail 1 "wp_load: cannot find 'Load' in" e];
+    [solve_mapsto ()
+    |wp_finish]
   | _ => fail "wp_load: not a 'wp'"
   end.
 
@@ -394,6 +491,12 @@ Tactic Notation "wp_store" :=
       |fail 1 "wp_store: cannot find 'Store' in" e];
     [iSolveTC
     |solve_mapsto ()
+    |pm_reduce; first [wp_seq|wp_finish]]
+  | |- envs_entails _ (twp ?s ?E ?e ?Q) =>
+    first
+      [reshape_expr e ltac:(fun K e' => eapply (tac_twp_store _ _ _ _ K))
+      |fail 1 "wp_store: cannot find 'Store' in" e];
+    [solve_mapsto ()
     |pm_reduce; first [wp_seq|wp_finish]]
   | _ => fail "wp_store: not a 'wp'"
   end.

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -44,8 +44,12 @@ Section adequacy.
         { iIntros (ρ2) "%Hρ2". iMod ("H" $! ρ2 Hρ2) as "H".
           destruct ρ2. iMod "H" as "(?&?&H)".
           iMod ("H" with "[$][$]"). iModIntro. iModIntro. done.
-        } 
-        admit.
+        }
+        iApply (fupd_mono _ _ (⌜∀ e, R e -> 1 - ε2 <= SeriesC (lim_exec e)⌝)%I).
+        { iIntros (H). iPureIntro. admit. }
+        iIntros (a HR). iMod ("H" $! a (HR)) as "H".
+        destruct a.
+        iApply "H".
       + iDestruct "H" as "(%R & %ε1 & %ε2 & %Hred & %Hbound & %Hineq & %Hub & H)".
         rewrite lim_exec_step step_or_final_no_final.
         2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. by eapply reducible_not_val. }
@@ -59,7 +63,11 @@ Section adequacy.
           destruct ρ2. iMod "H" as "(?&?&H)".
           iMod ("H" with "[$][$]"). iModIntro. iModIntro. done.
         }
-        admit.
+        iApply (fupd_mono _ _ (⌜∀ e, R e -> 1 - (ε2 e) <= SeriesC (lim_exec e)⌝)%I).
+        { iIntros (H). iPureIntro. admit. }
+        iIntros (a HR). iMod ("H" $! a (HR)) as "H".
+        destruct a.
+        iApply "H".
       + iInduction (language.get_active σ) as [| l] "IH".
         { rewrite big_orL_nil //. }
         rewrite !big_orL_cons.
@@ -69,7 +77,11 @@ Section adequacy.
         iAssert (∀ σ2 : language.state prob_lang,
                    ⌜R σ2⌝ ={∅}=∗ ⌜1 - ε2 <= SeriesC (lim_exec (e, σ2))⌝)%I with "[H]" as "H".
         { iIntros. iMod ("H" $! σ2 (H)) as "H". iDestruct "H" as "[H _]". iApply "H". done. }
-        admit.
+        iApply (fupd_mono _ _ (⌜∀ s, R s -> 1 - ε2 <= SeriesC (lim_exec (e, s))⌝)%I).
+        { iIntros (H). iPureIntro. admit. }
+        iIntros (a HR). iMod ("H" $! a (HR)) as "H".
+        destruct a.
+        iApply "H".
       + iInduction (language.get_active σ) as [| l] "IH".
         { rewrite big_orL_nil //. }
         rewrite !big_orL_cons.
@@ -79,7 +91,11 @@ Section adequacy.
         iAssert (∀ σ2 : language.state prob_lang,
                    ⌜R σ2⌝ ={∅}=∗ ⌜1 - (ε2 (e, σ2)) <= SeriesC (lim_exec (e, σ2))⌝)%I with "[H]" as "H".
         { iIntros. iMod ("H" $! σ2 (H)) as "H". iDestruct "H" as "[H _]". iApply "H". done. }
-        admit. 
+        iApply (fupd_mono _ _ (⌜∀ s, R s -> 1 - ε2 (e, s) <= SeriesC (lim_exec (e, s))⌝)%I).
+        { iIntros (H). iPureIntro. admit. }
+        iIntros (a HR). iMod ("H" $! a (HR)) as "H".
+        destruct a.
+        iApply "H".
   Admitted.
   
 End adequacy.

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -30,7 +30,7 @@ Section adequacy.
       iMod "H".
       iRevert (H).
       iApply (exec_ub_strong_ind (λ ε e σ, ⌜language.to_val e = None⌝ ={∅}=∗ ⌜1 - ε <= SeriesC (lim_exec (e, σ))⌝)%I with "[][$H]").
-      iModIntro. clear e σ ε. simpl. iIntros (e σ ε) "H %Hval".
+      iModIntro. clear e σ ε. iIntros (e σ ε) "H %Hval".
       iDestruct "H" as "[H|[H|[H|H]]]".
       + iDestruct "H" as "(%R & %ε1 & %ε2 & %Hred & %Hineq & %Hub & H)".
         rewrite lim_exec_step step_or_final_no_final.

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -25,6 +25,7 @@ Section adequacy.
     rewrite /ub_twp_pre.
     case_match.
     - iApply fupd_mask_intro; first done. iIntros "_".
+      iPureIntro.
       admit.
     - iSpecialize ("H" $! σ ε with "[$]").
       iMod "H".

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -442,5 +442,10 @@ Theorem twp_union_bound_lim_limit Σ `{ub_clutchGpreS Σ} (e : expr) (σ : state
   (∀ `{ub_clutchGS Σ}, (∀ ε':nonnegreal, ε'>ε -> ⊢ € ε' -∗ WP e [{ v, ⌜φ v⌝ }])) →
   ub_lift (lim_exec (e, σ)) φ ε.
 Proof.
-  (* This lemma can be proven with the continuity of ub_lift lemma in the pull request *)
-Admitted.
+  intros. eapply wp_union_bound_epsilon_lim; first done.
+  intros. iStartProof. iIntros "Herr". iApply ub_twp_ub_wp.
+  iAssert (WP e [{ v, ⌜φ v⌝ }])%I with "[Herr]" as "K".
+  2:{ destruct twp_default. destruct wp_default. done. }
+  iApply (H0 with "[$]").
+  apply Rlt_gt. done.
+Qed.

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -28,8 +28,40 @@ Section adequacy.
       admit.
     - iSpecialize ("H" $! σ ε with "[$]").
       iMod "H".
-      rewrite exec_ub_unfold.
-      iDestruct "H" as "[H|[H|[H|H]]]".
+      rewrite /exec_ub /exec_ub'.
+      iPoseProof (least_fixpoint_ind with "[][$H]") as "IH".
+      { apply exec_coupl_pre_mono. }
+      (* iDestruct "H" as "[H|[H|[H|H]]]". *)
+      (* + iDestruct "H" as "(%R & %ε1 & %ε2 & %Hred & %Hineq & %Hub & H)". *)
+      (*   rewrite lim_exec_step step_or_final_no_final. *)
+      (*   2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. by eapply reducible_not_val. } *)
+      (*   rewrite dbind_mass.  *)
+      (*   admit.  *)
+      (* + iDestruct "H" as "(%R & %ε1 & %ε2 & %Hred & %Hbound & %Hineq & %Hub & H)". *)
+      (*   rewrite lim_exec_step step_or_final_no_final. *)
+      (*   2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. by eapply reducible_not_val. } *)
+      (*   rewrite dbind_mass. *)
+      (*   admit.  *)
+      (* + iInduction (language.get_active σ) as [| l] "IH". *)
+      (*   { rewrite big_orL_nil //. } *)
+      (*   rewrite !big_orL_cons. *)
+      (*   iDestruct "H" as "[H|H]". *)
+      (*   2:{ by iApply "IH". } *)
+      (*   iDestruct "H" as "(%R & %ε1 & %ε2 & %Hineq & %Hub & H)". *)
+      (*   rewrite lim_exec_step step_or_final_no_final. *)
+      (*   2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. done. } *)
+      (*   rewrite dbind_mass. *)
+      (*   admit.  *)
+      (* + iInduction (language.get_active σ) as [| l] "IH". *)
+      (*   { rewrite big_orL_nil //. } *)
+      (*   rewrite !big_orL_cons. *)
+      (*   iDestruct "H" as "[H|H]". *)
+      (*   2:{ by iApply "IH". } *)
+      (*   iDestruct "H" as "(%R & %ε1 & %ε2  & %Hbound & %Hineq & %Hub & H)". *)
+      (*   rewrite lim_exec_step step_or_final_no_final. *)
+      (*   2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. done. } *)
+      (*   rewrite dbind_mass. *)
+      (*   admit. *) 
   Admitted.
   
 End adequacy.

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -15,7 +15,7 @@ Section adequacy.
   Proof.
     iIntros "(Hstate & Herr & Htwp)".
     iRevert (σ ε) "Hstate Herr".
-    pose proof (ub_twp_ind' ⊤ ()  (λ _ e _, ∀ (a : state) (a0 : nonnegreal),
+    pose proof (ub_twp_ind' ⊤ ()  (λ e _, ∀ (a : state) (a0 : nonnegreal),
                                   state_interp a -∗ err_interp a0 ={⊤,∅}=∗ ⌜1 - a0 <= SeriesC (lim_exec (e, a))⌝)%I) as H. iApply H.
     2: { destruct twp_default. done. }
     clear H e.

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -36,11 +36,29 @@ Section adequacy.
         rewrite lim_exec_step step_or_final_no_final.
         2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. by eapply reducible_not_val. }
         rewrite dbind_mass.
+        iAssert (∀ ρ2 : language.expr prob_lang * language.state prob_lang,
+          ⌜R ρ2⌝ ={∅}=∗
+          let
+          '(e2, σ2) := ρ2 in
+          |={∅}=> ⌜1 - ε2 <= SeriesC (lim_exec (e2, σ2))⌝)%I with "[H]" as "H".
+        { iIntros (ρ2) "%Hρ2". iMod ("H" $! ρ2 Hρ2) as "H".
+          destruct ρ2. iMod "H" as "(?&?&H)".
+          iMod ("H" with "[$][$]"). iModIntro. iModIntro. done.
+        } 
         admit.
       + iDestruct "H" as "(%R & %ε1 & %ε2 & %Hred & %Hbound & %Hineq & %Hub & H)".
         rewrite lim_exec_step step_or_final_no_final.
         2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. by eapply reducible_not_val. }
         rewrite dbind_mass.
+        iAssert (∀ ρ2 : language.expr prob_lang * language.state prob_lang,
+          ⌜R ρ2⌝ ={∅}=∗
+          let
+          '(e2, σ2) := ρ2 in
+          |={∅}=> ⌜1 - (ε2 ρ2) <= SeriesC (lim_exec (e2, σ2))⌝)%I with "[H]" as "H".
+        { iIntros (ρ2) "%Hρ2". iMod ("H" $! ρ2 Hρ2) as "H".
+          destruct ρ2. iMod "H" as "(?&?&H)".
+          iMod ("H" with "[$][$]"). iModIntro. iModIntro. done.
+        }
         admit.
       + iInduction (language.get_active σ) as [| l] "IH".
         { rewrite big_orL_nil //. }
@@ -48,6 +66,9 @@ Section adequacy.
         iDestruct "H" as "[H|H]".
         2:{ by iApply "IH". }
         iDestruct "H" as "(%R & %ε1 & %ε2 & %Hineq & %Hub & H)".
+        iAssert (∀ σ2 : language.state prob_lang,
+                   ⌜R σ2⌝ ={∅}=∗ ⌜1 - ε2 <= SeriesC (lim_exec (e, σ2))⌝)%I with "[H]" as "H".
+        { iIntros. iMod ("H" $! σ2 (H)) as "H". iDestruct "H" as "[H _]". iApply "H". done. }
         admit.
       + iInduction (language.get_active σ) as [| l] "IH".
         { rewrite big_orL_nil //. }
@@ -55,6 +76,9 @@ Section adequacy.
         iDestruct "H" as "[H|H]".
         2:{ by iApply "IH". }
         iDestruct "H" as "(%R & %ε1 & %ε2  & %Hbound & %Hineq & %Hub & H)".
+        iAssert (∀ σ2 : language.state prob_lang,
+                   ⌜R σ2⌝ ={∅}=∗ ⌜1 - (ε2 (e, σ2)) <= SeriesC (lim_exec (e, σ2))⌝)%I with "[H]" as "H".
+        { iIntros. iMod ("H" $! σ2 (H)) as "H". iDestruct "H" as "[H _]". iApply "H". done. }
         admit. 
   Admitted.
   

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -26,7 +26,11 @@ Section adequacy.
     case_match.
     - iApply fupd_mask_intro; first done. iIntros "_".
       iPureIntro.
-      admit.
+      etrans.
+      2:{ eapply SeriesC_ge_elem; last done. intros. apply pmf_pos. }
+      erewrite (lim_exec_term 0).
+      { simpl. rewrite H. rewrite dret_1_1; last done. destruct ε. simpl. lra. }
+      simpl. rewrite H. by rewrite dret_mass.
     - iSpecialize ("H" $! σ ε with "[$]").
       iMod "H".
       iRevert (H).

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -28,40 +28,34 @@ Section adequacy.
       admit.
     - iSpecialize ("H" $! σ ε with "[$]").
       iMod "H".
-      rewrite /exec_ub /exec_ub'.
-      iPoseProof (least_fixpoint_ind with "[][$H]") as "IH".
-      { apply exec_coupl_pre_mono. }
-      (* iDestruct "H" as "[H|[H|[H|H]]]". *)
-      (* + iDestruct "H" as "(%R & %ε1 & %ε2 & %Hred & %Hineq & %Hub & H)". *)
-      (*   rewrite lim_exec_step step_or_final_no_final. *)
-      (*   2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. by eapply reducible_not_val. } *)
-      (*   rewrite dbind_mass.  *)
-      (*   admit.  *)
-      (* + iDestruct "H" as "(%R & %ε1 & %ε2 & %Hred & %Hbound & %Hineq & %Hub & H)". *)
-      (*   rewrite lim_exec_step step_or_final_no_final. *)
-      (*   2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. by eapply reducible_not_val. } *)
-      (*   rewrite dbind_mass. *)
-      (*   admit.  *)
-      (* + iInduction (language.get_active σ) as [| l] "IH". *)
-      (*   { rewrite big_orL_nil //. } *)
-      (*   rewrite !big_orL_cons. *)
-      (*   iDestruct "H" as "[H|H]". *)
-      (*   2:{ by iApply "IH". } *)
-      (*   iDestruct "H" as "(%R & %ε1 & %ε2 & %Hineq & %Hub & H)". *)
-      (*   rewrite lim_exec_step step_or_final_no_final. *)
-      (*   2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. done. } *)
-      (*   rewrite dbind_mass. *)
-      (*   admit.  *)
-      (* + iInduction (language.get_active σ) as [| l] "IH". *)
-      (*   { rewrite big_orL_nil //. } *)
-      (*   rewrite !big_orL_cons. *)
-      (*   iDestruct "H" as "[H|H]". *)
-      (*   2:{ by iApply "IH". } *)
-      (*   iDestruct "H" as "(%R & %ε1 & %ε2  & %Hbound & %Hineq & %Hub & H)". *)
-      (*   rewrite lim_exec_step step_or_final_no_final. *)
-      (*   2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. done. } *)
-      (*   rewrite dbind_mass. *)
-      (*   admit. *) 
+      iRevert (H).
+      iApply (exec_ub_strong_ind (λ ε e σ, ⌜language.to_val e = None⌝ ={∅}=∗ ⌜1 - ε <= SeriesC (lim_exec (e, σ))⌝)%I with "[][$H]").
+      iModIntro. clear e σ ε. simpl. iIntros (e σ ε) "H %Hval".
+      iDestruct "H" as "[H|[H|[H|H]]]".
+      + iDestruct "H" as "(%R & %ε1 & %ε2 & %Hred & %Hineq & %Hub & H)".
+        rewrite lim_exec_step step_or_final_no_final.
+        2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. by eapply reducible_not_val. }
+        rewrite dbind_mass.
+        admit.
+      + iDestruct "H" as "(%R & %ε1 & %ε2 & %Hred & %Hbound & %Hineq & %Hub & H)".
+        rewrite lim_exec_step step_or_final_no_final.
+        2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. by eapply reducible_not_val. }
+        rewrite dbind_mass.
+        admit.
+      + iInduction (get_active σ) as [| l] "IH".
+        { rewrite big_orL_nil //. }
+        rewrite !big_orL_cons.
+        iDestruct "H" as "[H|H]".
+        2:{ by iApply "IH". }
+        iDestruct "H" as "(%R & %ε1 & %ε2 & %Hineq & %Hub & H)".
+        admit.
+      + iInduction (get_active σ) as [| l] "IH".
+        { rewrite big_orL_nil //. }
+        rewrite !big_orL_cons.
+        iDestruct "H" as "[H|H]".
+        2:{ by iApply "IH". }
+        iDestruct "H" as "(%R & %ε1 & %ε2  & %Hbound & %Hineq & %Hub & H)".
+        admit. 
   Admitted.
   
 End adequacy.

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -64,4 +64,32 @@ Proof.
   iAssert (WP e [{ v, ⌜φ v⌝ }])%I with "[Hε]" as "H".
   2:{ destruct twp_default. destruct wp_default. iExact "H". }
   by iApply H0.
-Qed. 
+Qed.
+
+(** limit rules *)
+Theorem twp_mass_lim_exec_limit Σ `{ub_clutchGpreS Σ} (e : expr) (σ : state) (ε : nonnegreal) φ :
+  (∀ `{ub_clutchGS Σ}, (∀ ε' : nonnegreal, ε' > ε -> ⊢ € ε' -∗ WP e [{ v, ⌜φ v⌝ }])) →
+  (1 - ε <= SeriesC (lim_exec (e, σ)))%R.
+Proof.
+  intros H'.
+  apply real_le_limit.
+  intros ε0 H1.
+  replace (1-_-_) with (1- (ε+ε0)) by lra.
+  assert (0<=ε+ ε0) as Hε0.
+  { trans ε; try lra. by destruct ε. }
+  pose (mknonnegreal (ε+ε0) Hε0) as NNRε0.
+  assert (ε+ε0 = (NNRbar_to_real (NNRbar.Finite (NNRε0)))) as Heq.
+  { by simpl. }
+  rewrite Heq.
+  eapply twp_mass_lim_exec; first done.
+  intros. iIntros "He".
+  iApply H'; try iFrame.
+  simpl. destruct ε; simpl in H1; simpl; lra.
+Qed.
+
+Theorem twp_union_bound_lim_limit Σ `{ub_clutchGpreS Σ} (e : expr) (σ : state) (ε : nonnegreal) φ :
+  (∀ `{ub_clutchGS Σ}, (∀ ε':nonnegreal, ε'>ε -> ⊢ € ε' -∗ WP e [{ v, ⌜φ v⌝ }])) →
+  ub_lift (lim_exec (e, σ)) φ ε.
+Proof.
+  (* This lemma can be proven with the continuity of ub_lift lemma in the pull request *)
+Admitted.

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -42,14 +42,14 @@ Section adequacy.
         2: { rewrite /is_final. rewrite -eq_None_not_Some. simpl. by eapply reducible_not_val. }
         rewrite dbind_mass.
         admit.
-      + iInduction (get_active σ) as [| l] "IH".
+      + iInduction (language.get_active σ) as [| l] "IH".
         { rewrite big_orL_nil //. }
         rewrite !big_orL_cons.
         iDestruct "H" as "[H|H]".
         2:{ by iApply "IH". }
         iDestruct "H" as "(%R & %ε1 & %ε2 & %Hineq & %Hub & H)".
         admit.
-      + iInduction (get_active σ) as [| l] "IH".
+      + iInduction (language.get_active σ) as [| l] "IH".
         { rewrite big_orL_nil //. }
         rewrite !big_orL_cons.
         iDestruct "H" as "[H|H]".

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -15,20 +15,21 @@ Section adequacy.
   Proof.
     iIntros "(Hstate & Herr & Htwp)".
     iRevert (σ ε) "Hstate Herr".
-    pose proof (ub_twp_ind ()  (λ _ e _, ∀ (a : state) (a0 : nonnegreal),
-                                  state_interp a -∗ err_interp a0 ={⊤,∅}=∗ ⌜1 - a0 <= SeriesC (lim_exec (e, a))⌝)%I) as H.
-    simpl in H.
-    iApply H.
+    pose proof (ub_twp_ind' ⊤ ()  (λ _ e _, ∀ (a : state) (a0 : nonnegreal),
+                                  state_interp a -∗ err_interp a0 ={⊤,∅}=∗ ⌜1 - a0 <= SeriesC (lim_exec (e, a))⌝)%I) as H. iApply H.
     2: { destruct twp_default. done. }
     clear H e.
     iModIntro.
-    iIntros (e E Φ) "H".
-    iIntros (σ ε) "[Hheap Htapes] Hec".
+    iIntros (e Φ) "H".
+    iIntros (σ ε) "Hs Hec".
     rewrite /ub_twp_pre.
     case_match.
     - iApply fupd_mask_intro; first done. iIntros "_".
       admit.
-    - iSpecialize ("H" $! σ ε). 
+    - iSpecialize ("H" $! σ ε with "[$]").
+      iMod "H".
+      rewrite exec_ub_unfold.
+      iDestruct "H" as "[H|[H|[H|H]]]".
   Admitted.
   
 End adequacy.

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -7,22 +7,246 @@ From clutch.prob Require Import distribution union_bounds.
 Import uPred.
 
 Lemma twp_step_fupd_ineq_prim_step (e : language.expr prob_lang) σ (ε ε1:nonnegreal) (ε2: language.cfg prob_lang -> nonnegreal) R:
+  reducible e σ -> 
   (∃ r, ∀ ρ : language.cfg prob_lang, ε2 ρ <= r) ->
   ε1 + SeriesC
          (λ ρ, prim_step e σ ρ * ε2 ρ) <= ε -> ub_lift (prim_step e σ) R ε1 ->
   (∀ e, R e → 1 - ε2 e <= SeriesC (lim_exec e)) ->
   1 - ε <= SeriesC (λ a, step (e, σ) a * SeriesC (lim_exec a)).
 Proof.
-Admitted.
+  intros Hred Hbound Hsum Hub H.
+  simpl.
+  assert (1 - (ε1 + SeriesC (λ ρ, prim_step e σ ρ * ε2 ρ)) <=
+            SeriesC (λ a, prim_step e σ a * SeriesC (lim_exec a))) as Hint; last first.
+  { etrans; last exact. apply Rminus_le. lra. }
+  rewrite Rcomplements.Rle_minus_l Rplus_comm Rplus_assoc.
+  rewrite <-SeriesC_plus; last first.
+  { eapply ex_seriesC_le; last first.
+    - instantiate (1 := prim_step e σ).
+      apply pmf_ex_seriesC.
+    -  intros. split.
+       + by apply Rmult_le_pos.
+       + rewrite <-Rmult_1_r. by apply Rmult_le_compat_l.
+  }
+  { destruct Hbound as [r ?]. eapply ex_seriesC_le; last first.
+    - instantiate (1 := λ ρ, prim_step e σ ρ * r).
+      apply ex_seriesC_scal_r.
+      apply pmf_ex_seriesC.
+    -  intros. split.
+       + apply Rmult_le_pos; first done. apply cond_nonneg. 
+       + by apply Rmult_le_compat_l.
+  }
+  erewrite SeriesC_ext; last first.
+  { intros n. by rewrite <-Rmult_plus_distr_l. }
+  simpl in Hub, H, R. simpl.
+  assert (forall ρ, Decision (R ρ)) as Hdec.
+  { intros. apply make_decision. }
+  rewrite (SeriesC_ext _
+             (λ ρ, (if bool_decide(R ρ) then prim_step e σ ρ * (ε2 ρ + SeriesC (lim_exec ρ)) else 0)+
+                     if bool_decide (~R ρ) then prim_step e σ ρ * (ε2 ρ + SeriesC (lim_exec ρ)) else 0
+          )); last first.
+  { intros. repeat case_bool_decide; try done.
+    - by rewrite Rplus_0_r.
+    - by rewrite Rplus_0_l.
+  }
+  rewrite SeriesC_plus; last first.
+  { eapply ex_seriesC_filter_pos.
+    - intros. apply Rmult_le_pos; first done.
+      apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+    - destruct Hbound as [r?].
+      eapply ex_seriesC_ext; last first.
+      + eapply pmf_ex_seriesC_mult_fn. shelve.
+      + intros. simpl. f_equal.
+        Unshelve. exists (r+1).
+        intros; split.
+        * apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+        * by apply Rplus_le_compat.
+  }
+  { eapply ex_seriesC_filter_pos.
+    - intros. apply Rmult_le_pos; first done.
+      apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+    - destruct Hbound as [r?].
+      eapply ex_seriesC_ext; last first.
+      + eapply pmf_ex_seriesC_mult_fn. shelve.
+      + intros. simpl. f_equal.
+        Unshelve. exists (r+1).
+        intros; split.
+        * apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+        * by apply Rplus_le_compat.
+  }
+  trans (ε1 +
+  (SeriesC
+     (λ x : expr * state,
+        if bool_decide (R x) then prim_step e σ x else 0) +
+   SeriesC
+     (λ x : expr * state,
+        if bool_decide (¬ R x) then prim_step e σ x * (ε2 x + SeriesC (lim_exec x)) else 0))).
+  2:{ apply Rplus_le_compat_l. apply Rplus_le_compat_r.
+      apply SeriesC_le.
+      - intros. case_bool_decide; last done.
+        split; [apply pmf_pos|].
+        rewrite -{1}(Rmult_1_r (prim_step _ _ _)). apply Rmult_le_compat_l; [apply pmf_pos|].
+        pose proof (H n H0).
+        rewrite Rplus_comm. by rewrite <-Rcomplements.Rle_minus_l.
+      - apply ex_seriesC_filter_pos.
+        + intros. apply Rmult_le_pos; [apply pmf_pos|].
+          apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+        + apply pmf_ex_seriesC_mult_fn. destruct Hbound as [r?]. exists (r+1).
+          intros; split.
+          * apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+          * by apply Rplus_le_compat.
+  }
+  trans (ε1 +
+           (SeriesC (λ x : expr * state, if bool_decide (R x) then prim_step e σ x else 0))); last first.
+  { rewrite -Rplus_assoc. rewrite -{1}(Rplus_0_r (_+_)).
+    apply Rplus_le_compat_l. apply SeriesC_ge_0'.
+    intros. case_bool_decide; try lra.
+    apply Rmult_le_pos; [apply pmf_pos|].
+    apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+  }
+  rewrite /ub_lift in Hub.
+  assert (prob (prim_step e σ) (∽(λ ρ, bool_decide(R ρ)))%P <= ε1).
+  { apply Hub. intros. by apply bool_decide_eq_true_2. }
+  etrans.
+  2: { apply Rplus_le_compat_r. exact. }
+  rewrite /prob. simpl.
+  rewrite <-SeriesC_plus; last first.
+  - apply ex_seriesC_filter_pos; [apply pmf_pos|apply pmf_ex_seriesC].
+  - eapply ex_seriesC_ext.
+    + intros. by rewrite <- bool_decide_not.
+    + apply ex_seriesC_filter_pos; [apply pmf_pos|apply pmf_ex_seriesC].
+  - rewrite (SeriesC_ext _ (λ ρ, prim_step e σ ρ)); last first.
+    { intros. case_bool_decide; simpl.
+      - apply Rplus_0_l.
+      - apply Rplus_0_r.
+    }
+    simpl. apply Req_le_sym.
+    epose proof (@prim_step_mass prob_lang) as K. simpl in K.
+    apply K. apply Hred.
+Qed.
 
 Lemma twp_step_fupd_ineq_state_step (e : language.expr prob_lang) σ l (ε ε1:nonnegreal) (ε2: _ -> nonnegreal) R:
+  l ∈ language.get_active σ -> 
   (∃ r, ∀ ρ : language.cfg prob_lang, ε2 ρ <= r) ->
   ε1 + SeriesC
          (λ ρ, language.state_step σ l ρ * ε2 (e, ρ)) <= ε -> ub_lift (language.state_step σ l) R ε1 ->
   (∀ s, R s → 1 - ε2 (e, s) <= SeriesC (lim_exec (e, s))) ->
   1 - ε <= SeriesC (λ a, state_step σ l a * SeriesC (lim_exec (e, a))).
 Proof.
-Admitted.
+intros Hred Hbound Hsum Hub H.
+  simpl.
+  assert (1 - (ε1 + SeriesC (λ ρ, state_step σ l ρ * ε2 (e, ρ))) <=
+            SeriesC (λ a, state_step σ l a * SeriesC (lim_exec (e, a)))) as Hint; last first.
+  { etrans; last exact. rewrite -Ropp_minus_distr -(Ropp_minus_distr (_+_)).
+    apply Ropp_le_cancel. rewrite !Ropp_involutive Rcomplements.Rle_minus_l.
+    rewrite Rplus_assoc Rplus_opp_l Rplus_0_r. done.
+  }
+  rewrite Rcomplements.Rle_minus_l Rplus_comm Rplus_assoc.
+  rewrite <-SeriesC_plus; last first.
+  { eapply ex_seriesC_le; last first.
+    - instantiate (1 := state_step σ l).
+      apply pmf_ex_seriesC.
+    -  intros. split.
+       + by apply Rmult_le_pos.
+       + rewrite <-Rmult_1_r. by apply Rmult_le_compat_l.
+  }
+  { destruct Hbound as [r ?]. eapply ex_seriesC_le; last first.
+    - instantiate (1 := λ ρ, state_step σ l ρ * r).
+      apply ex_seriesC_scal_r.
+      apply pmf_ex_seriesC.
+    -  intros. split.
+       + apply Rmult_le_pos; first done. apply cond_nonneg. 
+       + by apply Rmult_le_compat_l.
+  }
+  erewrite SeriesC_ext; last first.
+  { intros n. by rewrite <-Rmult_plus_distr_l. }
+  simpl in Hub, H, R. simpl.
+  assert (forall ρ, Decision (R ρ)) as Hdec.
+  { intros. apply make_decision. }
+  rewrite (SeriesC_ext _
+             (λ ρ, (if bool_decide(R ρ) then state_step σ l ρ * (ε2 (e, ρ) + SeriesC (lim_exec (e, ρ))) else 0)+
+                     if bool_decide (~R ρ) then state_step σ l ρ * (ε2 (e, ρ) + SeriesC (lim_exec (e, ρ))) else 0
+          )); last first.
+  { intros. repeat case_bool_decide; try done.
+    - by rewrite Rplus_0_r.
+    - by rewrite Rplus_0_l.
+  }
+  rewrite SeriesC_plus; last first.
+  { eapply ex_seriesC_filter_pos.
+    - intros. apply Rmult_le_pos; first done.
+      apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+    - destruct Hbound as [r?].
+      eapply ex_seriesC_ext; last first.
+      + eapply pmf_ex_seriesC_mult_fn. shelve.
+      + intros. simpl. f_equal.
+        Unshelve. exists (r+1).
+        intros; split.
+        * apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+        * by apply Rplus_le_compat.
+  }
+  { eapply ex_seriesC_filter_pos.
+    - intros. apply Rmult_le_pos; first done.
+      apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+    - destruct Hbound as [r?].
+      eapply ex_seriesC_ext; last first.
+      + eapply pmf_ex_seriesC_mult_fn. shelve.
+      + intros. simpl. f_equal.
+        Unshelve. exists (r+1).
+        intros; split.
+        * apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+        * by apply Rplus_le_compat.
+  }
+  trans (ε1 +
+  (SeriesC
+     (λ x,
+        if bool_decide (R x) then state_step σ l x else 0) +
+   SeriesC
+     (λ x,
+        if bool_decide (¬ R x) then state_step σ l x * (ε2 (e, x) + SeriesC (lim_exec (e, x))) else 0))).
+  2:{ apply Rplus_le_compat_l. apply Rplus_le_compat_r.
+      apply SeriesC_le.
+      - intros. case_bool_decide; last done.
+        split; [apply pmf_pos|].
+        rewrite -{1}(Rmult_1_r (state_step _ _ _)). apply Rmult_le_compat_l; [apply pmf_pos|].
+        pose proof (H n H0).
+        rewrite Rplus_comm. by rewrite <-Rcomplements.Rle_minus_l.
+      - apply ex_seriesC_filter_pos.
+        + intros. apply Rmult_le_pos; [apply pmf_pos|].
+          apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+        + apply pmf_ex_seriesC_mult_fn. destruct Hbound as [r?]. exists (r+1).
+          intros; split.
+          * apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+          * by apply Rplus_le_compat.
+  }
+  trans (ε1 +
+           (SeriesC (λ x, if bool_decide (R x) then state_step σ l x else 0))); last first.
+  { rewrite -Rplus_assoc. rewrite -{1}(Rplus_0_r (_+_)).
+    apply Rplus_le_compat_l. apply SeriesC_ge_0'.
+    intros. case_bool_decide; try lra.
+    apply Rmult_le_pos; [apply pmf_pos|].
+    apply Rplus_le_le_0_compat; [apply cond_nonneg|apply pmf_SeriesC_ge_0].
+  }
+  rewrite /ub_lift in Hub.
+  assert (prob (state_step σ l) (∽(λ ρ, bool_decide(R ρ)))%P <= ε1).
+  { apply Hub. intros. by apply bool_decide_eq_true_2. }
+  etrans.
+  2: { apply Rplus_le_compat_r. exact. }
+  rewrite /prob. simpl.
+  rewrite <-SeriesC_plus; last first.
+  - apply ex_seriesC_filter_pos; [apply pmf_pos|apply pmf_ex_seriesC].
+  - eapply ex_seriesC_ext.
+    + intros. by rewrite <- bool_decide_not.
+    + apply ex_seriesC_filter_pos; [apply pmf_pos|apply pmf_ex_seriesC].
+  - rewrite (SeriesC_ext _ (λ ρ, state_step σ l ρ)); last first.
+    { intros. case_bool_decide; simpl.
+      - apply Rplus_0_l.
+      - apply Rplus_0_r.
+    }
+    simpl. apply Req_le_sym.
+    epose proof (@state_step_mass) as K. simpl in K.
+    apply K. simpl in Hred. rewrite /get_active in Hred.
+    set_solver. 
+Qed.
 
 Section adequacy.
   Context `{!ub_clutchGS Σ}.
@@ -119,6 +343,7 @@ Section adequacy.
           rewrite dbind_mass.
           erewrite SeriesC_ext.
           - eapply (twp_step_fupd_ineq_state_step _ _ _ _ _ (λ _, ε2)); try done.
+            + set_solver.
             + exists ε. intros. trans (ε1 + ε2); last lra. destruct ε1, ε2. simpl. lra.
             + rewrite SeriesC_scal_r. etrans; last exact Hineq.
               pose proof (pmf_SeriesC (language.state_step σ l)).
@@ -149,7 +374,8 @@ Section adequacy.
           simpl. erewrite SeriesC_ext; last by (intros; rewrite dret_id_right).
           rewrite dbind_mass.
           erewrite SeriesC_ext.
-          - by eapply twp_step_fupd_ineq_state_step.
+          - eapply twp_step_fupd_ineq_state_step; try done.
+            set_solver. 
           - intros; simpl. done.
         }    
         iIntros (a HR). iMod ("H" $! a (HR)) as "H".

--- a/theories/ub_logic/total_ectx_lifting.v
+++ b/theories/ub_logic/total_ectx_lifting.v
@@ -1,0 +1,99 @@
+From iris.proofmode Require Import proofmode.
+From clutch.common Require Import ectx_language.
+From clutch.ub_logic Require Import ub_total_weakestpre total_lifting.
+
+Local Open Scope R.
+
+Section twp.
+Context {Λ : ectxLanguage} `{!irisGS Λ Σ} {Hinh : Inhabited (state Λ)}.
+Implicit Types P : iProp Σ.
+Implicit Types Φ : val Λ → iProp Σ.
+Implicit Types v : val Λ.
+Implicit Types e : expr Λ.
+Local Hint Resolve head_prim_reducible head_reducible_prim_step : core.
+Local Definition reducible_not_val_inhabitant e := reducible_not_val e inhabitant.
+Local Hint Resolve reducible_not_val_inhabitant : core.
+Local Hint Resolve head_stuck_stuck : core.
+
+Lemma twp_lift_head_step_exec_ub {E Φ} e1 :
+  to_val e1 = None →
+  (∀ σ1 ε,
+    state_interp σ1 ∗ err_interp ε
+    ={E,∅}=∗
+    ⌜head_reducible e1 σ1⌝ ∗
+    exec_ub e1 σ1 (λ ε2 '(e2, σ2),
+      |={∅,E}=> state_interp σ2 ∗ err_interp ε2 ∗ WP e2 @ E [{ Φ }]) ε )
+  ⊢ WP e1 @ E [{ Φ }].
+Proof.
+  iIntros (?) "H". iApply twp_lift_step_fupd_exec_ub; [done|].
+  iIntros (σ1 ε) "Hσε".
+  iMod ("H" with "Hσε") as "[% H]"; iModIntro; auto.
+Qed.
+
+Lemma twp_lift_head_step {E Φ} e1 :
+  to_val e1 = None →
+  (∀ σ1, state_interp σ1 ={E,∅}=∗
+    ⌜head_reducible e1 σ1⌝ ∗
+     ∀ e2 σ2, ⌜head_step e1 σ1 (e2, σ2) > 0⌝ ={∅,E}=∗
+      state_interp σ2 ∗ WP e2 @ E [{ Φ }])
+  ⊢ WP e1 @ E [{ Φ }].
+Proof.
+  iIntros (?) "H". iApply twp_lift_step_fupd; [done|]. iIntros (?) "Hσ".
+  iMod ("H" with "Hσ") as "[% H]"; iModIntro.
+  iSplit; [by eauto|].
+  iIntros (???) "!>". iApply "H"; auto.
+Qed.
+
+Lemma twp_lift_atomic_head_step_fupd {E1 Φ} e1 :
+  to_val e1 = None →
+  (∀ σ1, state_interp σ1 ={E1}=∗
+    ⌜head_reducible e1 σ1⌝ ∗
+    ∀ e2 σ2, ⌜head_step e1 σ1 (e2, σ2) > 0⌝ ={E1}=∗
+      state_interp σ2 ∗
+      from_option Φ False (to_val e2))
+  ⊢ WP e1 @ E1 [{ Φ }].
+Proof.
+  iIntros (?) "H". iApply twp_lift_atomic_step_fupd; [done|].
+  iIntros (σ1) "Hσ1". iMod ("H" with "Hσ1") as "[% H]"; iModIntro.
+  iSplit; first by auto. iIntros (e2 σ2 Hstep).
+  iApply "H"; eauto.
+Qed.
+
+Lemma twp_lift_atomic_head_step {E Φ} e1 :
+  to_val e1 = None →
+  (∀ σ1, state_interp σ1 ={E}=∗
+    ⌜head_reducible e1 σ1⌝ ∗
+     ∀ e2 σ2, ⌜head_step e1 σ1 (e2, σ2) > 0⌝ ={E}=∗
+      state_interp σ2 ∗
+      from_option Φ False (to_val e2))
+  ⊢ WP e1 @ E [{ Φ }].
+Proof.
+  iIntros (?) "H". iApply twp_lift_atomic_step; eauto.
+  iIntros (σ1) "Hσ1". iMod ("H" with "Hσ1") as "[% H]"; iModIntro.
+  iSplit; [by auto|]. iIntros (e2 σ2 Hstep).
+  iApply "H"; eauto.
+Qed.
+
+Lemma twp_lift_pure_det_head_step {E Φ} e1 e2 :
+  to_val e1 = None →
+  (∀ σ1, head_reducible e1 σ1) →
+  (∀ σ1 e2' σ2,
+    head_step e1 σ1 (e2', σ2) > 0 → σ2 = σ1 ∧ e2' = e2) →
+  (|={E}=> WP e2 @ E [{ Φ }]) ⊢ WP e1 @ E [{ Φ }].
+Proof using Hinh.
+  intros. erewrite !(twp_lift_pure_det_step e1 e2); eauto.
+Qed.
+
+Lemma twp_lift_pure_det_head_step' {E Φ} e1 e2 :
+  to_val e1 = None →
+  (∀ σ1, head_reducible e1 σ1) →
+  (∀ σ1 e2' σ2,
+    head_step e1 σ1 (e2', σ2) > 0 → σ2 = σ1 ∧ e2' = e2) →
+   WP e2 @ E [{ Φ }] ⊢ WP e1 @ E [{ Φ }].
+Proof using Hinh.
+  intros. rewrite -[(WP e1 @ _ [{ _ }])%I] twp_lift_pure_det_head_step //.
+  iIntros. by iModIntro.
+Qed.
+
+
+End twp.

--- a/theories/ub_logic/total_lifting.v
+++ b/theories/ub_logic/total_lifting.v
@@ -1,0 +1,154 @@
+(** Total lifting lemmas for the ub logic*)
+From clutch.ub_logic Require Import ub_total_weakestpre.
+From iris.proofmode Require Import tactics.
+From clutch.prelude Require Import NNRbar.
+
+Section total_lifting.
+  Context `{!irisGS Λ Σ}.
+  Implicit Types v : val Λ.
+  Implicit Types e : expr Λ.
+  Implicit Types σ : state Λ.
+  Implicit Types P Q : iProp Σ.
+  Implicit Types Φ : val Λ → iProp Σ.
+  Local Open Scope R.
+
+  Lemma twp_lift_step_fupd_exec_ub E Φ e1 :
+  to_val e1 = None →
+  (∀ σ1 ε,
+    state_interp σ1 ∗ err_interp ε
+    ={E,∅}=∗
+    exec_ub e1 σ1 (λ ε2 '(e2, σ2),
+                      |={∅,E}=> state_interp σ2 ∗ err_interp ε2 ∗ WP e2 @ E [{ Φ }]) ε)
+  ⊢ WP e1 @ E [{ Φ }].
+  Proof.
+    by rewrite ub_twp_unfold /ub_twp_pre =>->.
+  Qed.
+
+  Lemma twp_lift_step_fupd E Φ e1 :
+  to_val e1 = None →
+  (∀ σ1, state_interp σ1
+     ={E,∅}=∗
+    ⌜reducible e1 σ1⌝ ∗
+     ∀ e2 σ2,
+      ⌜prim_step e1 σ1 (e2, σ2) > 0 ⌝ ={∅}=∗ |={∅,E}=>
+      state_interp σ2 ∗ WP e2 @ E [{ Φ }])
+  ⊢ WP e1 @ E [{ Φ }].
+  Proof.
+    intros Hval.
+    iIntros "H".
+    iApply twp_lift_step_fupd_exec_ub; [done|].
+    iIntros (σ1 ε) "[Hσ Hε]".
+    iMod ("H" with "Hσ") as "[%Hs H]". iModIntro.
+    iApply (exec_ub_prim_step e1 σ1).
+    iExists _.
+    iExists nnreal_zero.
+    iExists ε.
+    iSplit.
+    { iPureIntro. simpl. done. }
+    iSplit.
+    { iPureIntro. simpl. lra. }
+    iSplit.
+    { iPureIntro.
+      eapply ub_lift_pos_R, ub_lift_trivial.
+      simpl; lra.
+    }
+    iIntros ([e2 σ2] (?&?)).
+    iMod ("H" with "[//]")as "H".
+    iModIntro. iMod "H". iModIntro. iFrame. done.
+  Qed.
+
+  (** Derived lifting lemmas. *)
+  Lemma twp_lift_step E Φ e1 :
+    to_val e1 = None →
+    (∀ σ1, state_interp σ1 ={E,∅}=∗
+           ⌜reducible e1 σ1⌝ ∗
+           ∀ e2 σ2,
+       ⌜prim_step e1 σ1 (e2, σ2) > 0⌝ ={∅,E}=∗
+       state_interp σ2 ∗
+       WP e2 @ E [{ Φ }])
+    ⊢ WP e1 @ E [{ Φ }].
+  Proof.
+    iIntros (?) "H". iApply twp_lift_step_fupd; [done|]. iIntros (?) "Hσ".
+    iMod ("H" with "Hσ") as "[$ H]". iIntros "!>" (???) "!>" . iMod ("H" with "[]"); first done.
+    iModIntro; done.
+  Qed.
+
+  Lemma twp_lift_pure_step `{!Inhabited (state Λ)} E Φ e1 :
+    (∀ σ1, reducible e1 σ1) →
+    (∀ σ1 e2 σ2, prim_step e1 σ1 (e2, σ2) > 0 → σ2 = σ1) →
+    (|={E}=> ∀ e2 σ, ⌜prim_step e1 σ (e2, σ) > 0⌝ → WP e2 @ E [{ Φ }])
+    ⊢ WP e1 @ E [{ Φ }].
+  Proof.
+    iIntros (Hsafe Hstep) "H". iApply twp_lift_step.
+    { specialize (Hsafe inhabitant). eauto using reducible_not_val. }
+    iIntros (σ1) "Hσ". iMod "H".
+    iApply fupd_mask_intro; first set_solver. iIntros "Hclose".
+    iSplit; [done|].
+    iIntros (e2 σ2 Hprim).
+    destruct (Hstep _ _ _ Hprim).
+    iMod "Hclose" as "_". iModIntro.
+    iDestruct ("H" with "[//]") as "H". simpl. by iFrame.
+  Qed.
+
+  Lemma twp_lift_atomic_step_fupd {E1 Φ} e1 :
+  to_val e1 = None →
+  (∀ σ1, state_interp σ1 ={E1}=∗
+    ⌜reducible e1 σ1⌝ ∗
+    ∀ e2 σ2, ⌜prim_step e1 σ1 (e2, σ2) > 0⌝ ={E1}=∗
+      state_interp σ2 ∗
+      from_option Φ False (to_val e2))
+  ⊢ WP e1 @ E1 [{ Φ }].
+  Proof.
+    iIntros (?) "H".
+    iApply (twp_lift_step_fupd E1 _ e1)=>//; iIntros (σ1) "Hσ1".
+    iMod ("H" $! σ1 with "Hσ1") as "[$ H]".
+    iApply fupd_mask_intro; first set_solver.
+    iIntros "Hclose" (e2 σ2 Hs). iMod "Hclose" as "_".
+    iMod ("H" $! e2 σ2 with "[#]") as "[Hs ?]"; [done|].
+    iApply fupd_mask_intro; first set_solver. iIntros "Hclose".
+    iMod "Hclose" as "_". iModIntro. 
+    destruct (to_val e2) eqn:?; last (simpl; by iExFalso).
+    iFrame.
+    iApply ub_twp_value; last done. by apply of_to_val.
+  Qed.
+
+  Lemma twp_lift_atomic_step {E Φ} e1 :
+    to_val e1 = None →
+    (∀ σ1, state_interp σ1 ={E}=∗
+           ⌜reducible e1 σ1⌝ ∗
+          ∀ e2 σ2, ⌜prim_step e1 σ1 (e2, σ2) > 0⌝ ={E}=∗
+                    state_interp σ2 ∗
+                    from_option Φ False (to_val e2))
+  ⊢ WP e1 @ E [{ Φ }].
+  Proof.
+    iIntros (?) "H". iApply twp_lift_atomic_step_fupd; [done|].
+    iIntros (?) "?". iMod ("H" with "[$]") as "[$ H]".
+    iIntros "!> *". iIntros (Hstep).
+    by iApply "H".
+  Qed.
+
+  Lemma twp_lift_pure_det_step `{!Inhabited (state Λ)} {E Φ} e1 e2 :
+    (∀ σ1, reducible e1 σ1) →
+    (∀ σ1 e2' σ2, prim_step e1 σ1 (e2', σ2) > 0 → σ2 = σ1 ∧ e2' = e2) →
+    (|={E}=> WP e2 @ E [{ Φ }]) ⊢ WP e1 @ E [{ Φ }].
+  Proof.
+    iIntros (? Hpuredet) "H". iApply (twp_lift_pure_step E); try done.
+    { naive_solver. }
+    iMod "H". iModIntro.
+    iIntros (e' σ (?&->)%Hpuredet); auto.
+  Qed.
+
+  Lemma twp_pure_step_fupd `{!Inhabited (state Λ)} E e1 e2 φ n Φ :
+    PureExec φ n e1 e2 →
+    φ →
+    WP e2 @ E [{ Φ }] ⊢ WP e1 @ E [{ Φ }].
+  Proof.
+    iIntros (Hexec Hφ) "Hwp". specialize (Hexec Hφ).
+    iInduction Hexec as [e|n e1 e2 e3 [Hsafe ?]] "IH"; simpl; first done.
+    iApply twp_lift_pure_det_step.
+    - intros σ1 e2' σ2 Hpstep.
+      by injection (pmf_1_supp_eq _ _ _ (pure_step_det σ1) Hpstep).
+    - iModIntro. iApply "IH". iApply "Hwp". 
+  Qed.
+  
+End total_lifting.

--- a/theories/ub_logic/total_primitive_laws.v
+++ b/theories/ub_logic/total_primitive_laws.v
@@ -1,0 +1,134 @@
+From iris.proofmode Require Import proofmode.
+From clutch.ub_logic Require Export error_credits ub_total_weakestpre total_ectx_lifting primitive_laws.
+From clutch.prob_lang Require Import tactics lang notation.
+From clutch.prob_lang Require Export class_instances.
+
+Section total_primitive_laws.
+Context `{!ub_clutchGS Σ}.
+Implicit Types P Q : iProp Σ.
+Implicit Types Φ Ψ : val → iProp Σ.
+Implicit Types σ : state.
+Implicit Types v : val.
+Implicit Types l : loc.
+
+
+(** Heap *)
+Lemma twp_alloc E v :
+ [[{ True }]] Alloc (Val v) @ E [[{ l, RET LitV (LitLoc l); l ↦ v }]].
+Proof.
+  iIntros (Φ) "_ HΦ".
+  iApply twp_lift_atomic_head_step; [done|].
+  iIntros (σ1) "[Hh Ht] !#".
+  solve_red.
+  iIntros "/=" (e2 σ2 Hs); inv_head_step.
+  iMod ((ghost_map_insert (fresh_loc σ1.(heap)) v) with "Hh") as "[$ Hl]".
+  { apply not_elem_of_dom, fresh_loc_is_fresh. }
+  iIntros "!>". iFrame. by iApply "HΦ".
+Qed.
+
+Lemma twp_load E l dq v :
+  [[{ ▷ l ↦{dq} v }]] Load (Val $ LitV $ LitLoc l) @ E [[{ RET v; l ↦{dq} v }]].
+Proof.
+  iIntros (Φ) ">Hl HΦ".
+  iApply twp_lift_atomic_head_step; [done|].
+  iIntros (σ1) "[Hh Ht] !#".
+  iDestruct (ghost_map_lookup with "Hh Hl") as %?.
+  solve_red.
+  iIntros "/=" (e2 σ2 Hs); inv_head_step.
+  iFrame. iModIntro. by iApply "HΦ".
+Qed.
+
+Lemma twp_store E l v' v :
+  [[{ ▷ l ↦ v' }]] Store (Val $ LitV (LitLoc l)) (Val v) @ E
+  [[{ RET LitV LitUnit; l ↦ v }]].
+Proof.
+  iIntros (Φ) ">Hl HΦ".
+  iApply twp_lift_atomic_head_step; [done|].
+  iIntros (σ1) "[Hh Ht] !#".
+  iDestruct (ghost_map_lookup with "Hh Hl") as %?.
+  solve_red.
+  iIntros "/=" (e2 σ2 Hs); inv_head_step.
+  iMod (ghost_map_update with "Hh Hl") as "[$ Hl]".
+  iFrame. iModIntro. by iApply "HΦ".
+Qed.
+
+Lemma twp_rand (N : nat) (z : Z) E :
+  TCEq N (Z.to_nat z) →
+  [[{ True }]] rand #z @ E [[{ (n : fin (S N)), RET #n; True }]].
+Proof.
+  iIntros (-> Φ) "_ HΦ".
+  iApply twp_lift_atomic_head_step; [done|].
+  iIntros (σ1) "Hσ !#".
+  solve_red.
+  iIntros (e2 σ2 Hs).
+  inv_head_step.
+  iFrame.
+  by iApply ("HΦ" $! x) .
+Qed.
+
+
+(** Tapes  *)
+Lemma twp_alloc_tape N z E :
+  TCEq N (Z.to_nat z) →
+  [[{ True }]] alloc #z @ E [[{ α, RET #lbl:α; α ↪ (N; []) }]].
+Proof.
+  iIntros (-> Φ) "_ HΦ".
+  iApply twp_lift_atomic_head_step; [done|].
+  iIntros (σ1) "(Hh & Ht) !# /=".
+  solve_red.
+  iIntros (e2 σ2 Hs); inv_head_step.
+  iMod (ghost_map_insert (fresh_loc σ1.(tapes)) with "Ht") as "[$ Hl]".
+  { apply not_elem_of_dom, fresh_loc_is_fresh. }
+  iFrame. iModIntro.
+  by iApply "HΦ".
+Qed.
+
+Lemma twp_rand_tape N α n ns z E :
+  TCEq N (Z.to_nat z) →
+  [[{ ▷ α ↪ (N; n :: ns) }]] rand(#lbl:α) #z @ E [[{ RET #(LitInt n); α ↪ (N; ns) }]].
+Proof.
+  iIntros (-> Φ) ">Hl HΦ".
+  iApply twp_lift_atomic_head_step; [done|].
+  iIntros (σ1) "(Hh & Ht) !#".
+  iDestruct (ghost_map_lookup with "Ht Hl") as %?.
+  solve_red.
+  iIntros (e2 σ2 Hs).
+  inv_head_step.
+  iMod (ghost_map_update with "Ht Hl") as "[$ Hl]".
+  iFrame. iModIntro.
+  by iApply "HΦ".
+Qed.
+
+Lemma twp_rand_tape_empty N z α E :
+  TCEq N (Z.to_nat z) →
+  [[{ ▷ α ↪ (N; []) }]] rand(#lbl:α) #z @ E [[{ (n : fin (S N)), RET #(LitInt n); α ↪ (N; []) }]].
+Proof.
+  iIntros (-> Φ) ">Hl HΦ".
+  iApply twp_lift_atomic_head_step; [done|].
+  iIntros (σ1) "(Hh & Ht) !#".
+  iDestruct (ghost_map_lookup with "Ht Hl") as %?.
+  solve_red.
+  iIntros (e2 σ2 Hs).
+  inv_head_step.
+  iFrame.
+  iModIntro. iApply ("HΦ" with "[$Hl //]").
+Qed.
+
+Lemma twp_rand_tape_wrong_bound N M z α E ns :
+  TCEq N (Z.to_nat z) →
+  N ≠ M →
+  [[{ ▷ α ↪ (M; ns) }]] rand(#lbl:α) #z @ E [[{ (n : fin (S N)), RET #(LitInt n); α ↪ (M; ns) }]].
+Proof.
+  iIntros (-> ? Φ) ">Hl HΦ".
+  iApply twp_lift_atomic_head_step; [done|].
+  iIntros (σ1) "(Hh & Ht) !#".
+  iDestruct (ghost_map_lookup with "Ht Hl") as %?.
+  solve_red.
+  iIntros (e2 σ2 Hs).
+  inv_head_step.
+  iFrame.
+  iModIntro.
+  iApply ("HΦ" with "[$Hl //]").
+Qed.
+
+End total_primitive_laws.

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -710,6 +710,39 @@ Proof.
 Qed.
 
 (** adapted from wp_couple_tapes in the relational logic *)
+Lemma twp_presample (N : nat) E e 𝛼 Φ ns :
+  to_val e = None →
+  𝛼 ↪ (N; ns) ∗
+  (∀ (n : fin (S N)), 𝛼 ↪ (N; ns ++ [n]) -∗ WP e @ E [{ Φ }])
+  ⊢ WP e @ E [{ Φ }].
+Proof.
+    iIntros (He) "(H𝛼&Hwp)".
+    iApply twp_lift_step_fupd_exec_ub; [done|].
+    iIntros (𝜎 ε) "((Hheap&Htapes)&Hε)".
+    iDestruct (ghost_map_lookup with "Htapes H𝛼") as %Hlookup.
+    iApply fupd_mask_intro; [set_solver|]; iIntros "Hclose'".
+    replace ε with (nnreal_zero + ε)%NNR by (apply nnreal_ext; simpl; lra).
+    iApply exec_ub_state_step.
+    { rewrite /= /get_active.
+      by apply elem_of_list_In, elem_of_list_In, elem_of_elements, elem_of_dom. }
+    iExists _.
+    iSplitR.
+    { iPureIntro. apply ub_lift_state, Hlookup. }
+    iIntros (𝜎') "[%n %H𝜎']".
+    iDestruct (ghost_map_lookup with "Htapes H𝛼") as %?%lookup_total_correct.
+    iMod (ghost_map_update ((N; ns ++ [n]) : tape) with "Htapes H𝛼") as "[Htapes H𝛼]".
+    iMod "Hclose'" as "_".
+    iSpecialize ("Hwp" $! n with "H𝛼").
+    rewrite !ub_twp_unfold /ub_twp_pre /= He.
+    iSpecialize ("Hwp" $! 𝜎' ε).
+    iMod ("Hwp" with "[Hheap Htapes Hε]") as "Hwp".
+    { replace (nnreal_zero + ε)%NNR with ε by (apply nnreal_ext; simpl; lra).
+      rewrite H𝜎'.
+      iFrame.
+    }
+    iModIntro. iApply "Hwp".
+Qed.
+
 Lemma wp_presample (N : nat) E e 𝛼 Φ ns :
   to_val e = None →
   ▷ 𝛼 ↪ (N; ns) ∗
@@ -741,6 +774,173 @@ Proof.
       iFrame.
     }
     iModIntro. iApply "Hwp".
+Qed.
+
+Lemma twp_presample_adv_comp (N : nat) z E e α Φ ns (ε1 : nonnegreal) (ε2 : fin (S N) -> nonnegreal) :
+  TCEq N (Z.to_nat z) →
+  to_val e = None →
+  SeriesC (λ n, (1 / (S N)) * ε2 n)%R = (nonneg ε1) →
+  α ↪ (N; ns) ∗
+  € ε1 ∗
+  (∀ (n : fin (S N)), € (ε2 n) ∗ α ↪ (N; ns ++ [n]) -∗ WP e @ E [{ Φ }])
+  ⊢ WP e @ E [{ Φ }].
+Proof.
+  iIntros (-> Hσ_red Hsum) "(Hα & Hε & Hwp)".
+  iApply twp_lift_step_fupd_exec_ub; [done|].
+  iIntros (σ1 ε_now) "[(Hheap&Htapes) Hε_supply]".
+  iDestruct (ghost_map_lookup with "Htapes Hα") as %Hlookup.
+  iDestruct (ec_supply_bound with "Hε_supply Hε") as %Hε1_ub.
+  iApply fupd_mask_intro; [set_solver|].
+  iIntros "Hclose".
+  iApply (exec_ub_state_adv_comp' α); simpl.
+  { rewrite /get_active.
+    apply elem_of_list_In, elem_of_list_In, elem_of_elements, elem_of_dom.
+    done. }
+  iDestruct (ec_split_supply with "Hε_supply Hε") as (ε_rem) "%Hε_supply".
+  rewrite Hε_supply.
+
+  (* R: predicate should hold iff tapes σ' at α is ns ++ [n] *)
+  iExists
+    (fun σ' : state => exists n : fin _, σ' = (state_upd_tapes <[α:=(_; ns ++ [n]) : tape]> σ1)),
+    (fun ρ => (ε_rem +
+              match finite.find (fun s => state_upd_tapes <[α:=(_; ns ++ [s]) : tape]> σ1 = snd ρ) with
+                | Some s => ε2 s
+                | None => nnreal_zero
+              end))%NNR.
+
+  (* upper bound on ε2 *)
+  iSplit.
+  { iPureIntro.
+    destruct (mean_constraint_ub _ _ _ Hsum) as [r [Hr_nonneg Hr_ub]].
+    assert (Hr_nnonneg : (0 <= r)%R).
+    { eapply Rle_trans; [|apply (Hr_ub 0%fin)].
+      rewrite match_nonneg_coercions.
+      apply cond_nonneg. }
+    exists (ε_rem + r)%R.
+    intros [e' σ'].
+    apply Rplus_le_compat_l.
+    destruct (finite.find _); auto; apply Hr_ub.
+  }
+
+  (* upper bound on total error *)
+  iSplit.
+  { iPureIntro. simpl.
+    rewrite -Hsum.
+    setoid_rewrite Rmult_plus_distr_l.
+    rewrite SeriesC_plus.
+    (* existence *)
+    2: { apply ex_seriesC_scal_r, pmf_ex_seriesC. }
+    2: { apply pmf_ex_seriesC_mult_fn.
+         destruct (mean_constraint_ub _ _ _ Hsum) as [r [Hr_nonneg Hr_ub]].
+         exists r; intros; split.
+         - apply cond_nonneg.
+         - destruct (finite.find _); [apply Hr_ub | simpl; apply Hr_nonneg]. }
+
+    rewrite -Rplus_comm; apply Rplus_le_compat; last first.
+    { (* holds because state_step is a pmf so is lt 1 *)
+      rewrite SeriesC_scal_r -{2}(Rmult_1_l (nonneg ε_rem)).
+      apply Rmult_le_compat; try auto; [apply cond_nonneg | lra]. }
+
+    (* rewrite to a form for SeriesC_le *)
+    pose f := (fun n : fin _ => 1 / S (Z.to_nat z) * ε2 n)%R.
+    rewrite (SeriesC_ext
+               (λ x : state, state_step σ1 α x * _)%R
+               (fun x : state => from_option f 0
+                                (finite.find (fun n => state_upd_tapes <[α:=(_; ns ++ [n]) : tape]> σ1 = x ))%R));
+      last first.
+    { intros n.
+      destruct (finite.find _) as [sf|] eqn:HeqF.
+      - Opaque INR.
+        apply find_Some in HeqF.
+        simpl in HeqF; rewrite -HeqF.
+        rewrite /from_option /f.
+        apply Rmult_eq_compat_r.
+        rewrite /state_upd_tapes /=.
+        rewrite /pmf /state_step.
+        rewrite bool_decide_true; last first.
+        { rewrite elem_of_dom Hlookup /= /is_Some; by exists (Z.to_nat z; ns). }
+        rewrite (lookup_total_correct _ _ (Z.to_nat z; ns)); auto.
+        rewrite /dmap /dbind /dbind_pmf /pmf.
+        rewrite /= SeriesC_scal_l -{1}(Rmult_1_r (1 / _))%R.
+        rewrite /Rdiv Rmult_1_l; apply Rmult_eq_compat_l.
+        (* this series is 0 unless a = sf *)
+        rewrite /dret /dret_pmf.
+        rewrite -{2}(SeriesC_singleton sf 1%R).
+        apply SeriesC_ext; intros.
+        symmetry.
+        case_bool_decide; simplify_eq.
+        + rewrite bool_decide_true; auto.
+        + rewrite bool_decide_false; auto.
+          rewrite /not; intros Hcont.
+          rewrite /not in H; apply H.
+          rewrite /state_upd_tapes in Hcont.
+          assert (R1 : ((Z.to_nat z; ns ++ [sf]) : tape) = (Z.to_nat z; ns ++ [n0])).
+          { apply (insert_inv (tapes σ1) α). by inversion Hcont. }
+          apply Eqdep_dec.inj_pair2_eq_dec in R1; [|apply PeanoNat.Nat.eq_dec].
+          apply app_inv_head in R1.
+          by inversion R1.
+          Transparent INR.
+      - rewrite /from_option /INR /=. lra.
+    }
+
+    apply SeriesC_le_inj.
+    - (* f is nonnegative *)
+      intros.
+      apply Rmult_le_pos.
+      + rewrite /Rdiv.
+        apply Rmult_le_pos; try lra.
+        apply Rlt_le, Rinv_0_lt_compat, pos_INR_S.
+      + apply cond_nonneg.
+    - (* injection *)
+      intros ? ? ? HF1 HF2.
+      apply find_Some in HF1.
+      apply find_Some in HF2.
+      by rewrite -HF1 -HF2.
+    - (* existence *)
+      apply ex_seriesC_finite.
+  }
+
+  (* lifted lookup on tapes *)
+  iSplit.
+  {
+    iPureIntro.
+    eapply UB_mon_pred; last first.
+    - apply ub_lift_state. apply Hlookup.
+    - done.
+  }
+
+  iIntros ((heap2 & tapes2)) "[%sample %Hsample]".
+  iMod (ec_decrease_supply with "Hε_supply Hε") as "Hε_supply".
+  iMod (ec_increase_supply _ (ε2 sample) with "Hε_supply") as "[Hε_supply Hε]".
+  iMod (ghost_map_update ((Z.to_nat z; ns ++ [sample]) : tape) with "Htapes Hα") as "[Htapes Hα]".
+  iSpecialize ("Hwp" $! sample).
+  rewrite ub_twp_unfold /ub_twp_pre.
+  rewrite Hsample /=.
+  destruct (@find_is_Some _ _ _
+               (λ s : fin (S (Z.to_nat z)), state_upd_tapes <[α:=(Z.to_nat z; ns ++ [s])]> σ1 = state_upd_tapes <[α:=(Z.to_nat z; ns ++ [sample])]> σ1)
+               _ sample eq_refl)
+            as [r [Hfind Hr]].
+  rewrite Hfind.
+  replace r with sample; last first.
+  { rewrite /state_upd_tapes in Hr.
+    inversion Hr as [Heqt].
+    apply (insert_inv (tapes σ1) α) in Heqt.
+    apply Eqdep_dec.inj_pair2_eq_dec in Heqt; [|apply PeanoNat.Nat.eq_dec].
+    apply app_inv_head in Heqt.
+    by inversion Heqt. }
+  remember {| heap := heap2; tapes := tapes2 |} as σ2.
+  rewrite Hσ_red.
+  iSpecialize ("Hwp" with "[Hε Hα]"); first iFrame.
+  iSpecialize ("Hwp" $! σ2 _).
+  iSpecialize ("Hwp" with "[Hheap Htapes Hε_supply]").
+  { iSplitL "Hheap Htapes".
+    - rewrite /tapes_auth.
+      rewrite Heqσ2 in Hsample. inversion Hsample.
+      simplify_eq. simpl. iFrame.
+    - iFrame. }
+  rewrite -Hsample.
+  iMod "Hclose"; iMod "Hwp"; iModIntro.
+  done.
 Qed.
 
 Lemma wp_presample_adv_comp (N : nat) z E e α Φ ns (ε1 : nonnegreal) (ε2 : fin (S N) -> nonnegreal) :
@@ -917,16 +1117,27 @@ Proof.
   replace ε1 with ε2; [iFrame|by apply nnreal_ext].
 Qed.
 
+Lemma twp_ec_spend e E Φ ε :
+  (1 <= ε.(nonneg))%R →
+  (to_val e = None) ->
+  € ε -∗ WP e @ E [{ Φ }].
+Proof.
+  iIntros (? Hred) "Hε".
+  rewrite ub_twp_unfold /ub_twp_pre /= Hred.
+  iIntros (σ1 ε0) "(_&Hε_supply)".
+  iApply fupd_mask_intro; [set_solver|].
+  iIntros "Hclose'".
+Admitted.
+
 Lemma wp_ec_spend e E Φ ε :
   (1 <= ε.(nonneg))%R →
   (to_val e = None) ->
   € ε -∗ WP e @ E {{ Φ }}.
 Proof.
-  iIntros (? Hred) "Hε".
-  rewrite ub_wp_unfold /ub_wp_pre /= Hred.
-  iIntros (σ1 ε0) "(_&Hε_supply)".
-  iExFalso.
-Abort.
+  iIntros.
+  iApply ub_twp_ub_wp'.
+  iApply twp_ec_spend; try done.
+Qed.
 
 Lemma ec_spend_1 ε1 : (1 <= ε1.(nonneg))%R → € ε1 -∗ False.
 Proof. Admitted.
@@ -983,6 +1194,52 @@ Proof.
 Qed.
 
 
+Lemma twp_presample_amplify' N z e E α Φ (ε : posreal) L kwf prefix suffix_total (suffix_remaining : list (fin (S N))) :
+  TCEq N (Z.to_nat z) →
+  to_val e = None →
+  L = length suffix_total ->
+  (0 < L)%nat ->
+  (α ↪ (N; prefix) ∗
+   (€ (pos_to_nn ε))
+   ⊢ (∀ (i : nat) (HL : (i <= L)%nat),
+        (((∃ junk, α ↪ (N; prefix ++ junk) ∗ €(εAmp N L ε kwf)) ∨
+         (α ↪ (N; prefix ++ (take i suffix_total)) ∗ € (εR N L i ε (mk_fRwf N L i kwf HL))))
+         -∗ WP e @ E [{ Φ }])
+      -∗ WP e @ E [{ Φ }]))%I.
+Proof.
+  iIntros (? ? Htotal HLpos) "(Htape & Hcr_initial)".
+  iIntros (i HL).
+  iInduction i as [|i'] "IH" forall (suffix_remaining).
+  - iIntros "Hwp"; iApply "Hwp".
+    iRight. iSplitL "Htape".
+    + rewrite take_0 -app_nil_end. iFrame.
+    + iApply ec_spend_irrel; last iFrame.
+      rewrite /εR /fR /pos_to_nn /=; lra.
+  - iIntros "Hwand".
+    assert (HL' : (i' <= L)%nat) by lia.
+    iSpecialize ("IH" $! HL' _ with "Htape Hcr_initial").
+    iApply "IH". iIntros "[[%junk(Htape&Hcr)]|(Htape&Hcr)]".
+    + iApply "Hwand".
+      iLeft; iExists junk. iFrame.
+    + assert (Hi' : (i' < length suffix_total)%nat) by lia.
+      destruct (lookup_ex i' suffix_total Hi') as [target Htarget].
+      rewrite (take_S_r _ _ target); [|apply Htarget].
+      pose HMean := (εDistr_mean N L i' ε target (mk_fRwf N L (S i') kwf HL)).
+      wp_apply twp_presample_adv_comp; [done | apply HMean | ].
+      replace {| k_wf := kwf; i_ub := HL' |} with
+        (fRwf_dec_i N L i' {| k_wf := kwf; i_ub := HL |}); [|apply fRwf_ext].
+      iFrame.
+      iIntros (s) "(Htape&Hcr)".
+      iApply "Hwand".
+      rewrite /εDistr.
+      case_bool_decide.
+      * iRight. simplify_eq; rewrite app_assoc; iFrame.
+      * iLeft. iExists (take i' suffix_total ++ [s]).
+        replace (k_wf N L (S i') {| k_wf := kwf; i_ub := HL |}) with kwf; last by apply kwf_ext.
+        rewrite -app_assoc; iFrame.
+    Unshelve. auto.
+Qed.
+
 Lemma presample_amplify' N z e E α Φ (ε : posreal) L kwf prefix suffix_total (suffix_remaining : list (fin (S N))) :
   TCEq N (Z.to_nat z) →
   to_val e = None →
@@ -1030,6 +1287,29 @@ Proof.
 Qed.
 
 (* do one step in the amplification sequence *)
+Lemma twp_presample_amplify N z e E α Φ (ε : posreal) L (kwf: kwf N L) prefix suffix :
+  TCEq N (Z.to_nat z) →
+  to_val e = None →
+  L = (length suffix) ->
+  € (pos_to_nn ε) ∗
+  (α ↪ (N; prefix)) ∗
+  ((α ↪ (N; prefix ++ suffix) ∨ (∃ junk, α ↪ (N; prefix ++ junk) ∗ €(εAmp N L ε kwf))) -∗ WP e @ E [{ Φ }])
+  ⊢ WP e @ E [{ Φ }].
+Proof.
+  iIntros (? ? Hl) "(Hcr & Htape & Hwp)".
+  destruct suffix as [|s0 sr].
+  - iApply "Hwp". iLeft. rewrite -app_nil_end. iFrame.
+  - remember (s0 :: sr) as suffix.
+    assert (Hl_pos : (0 < L)%nat).
+    { rewrite Hl Heqsuffix cons_length. lia. }
+    iApply (twp_presample_amplify' with "[Htape Hcr]"); eauto; [iFrame|].
+    iIntros "[H|(H&_)]"; iApply "Hwp".
+    + iRight. by iFrame.
+    + iLeft. erewrite firstn_all; iFrame.
+ Unshelve. lia.
+Qed.
+
+(* do one step in the amplification sequence *)
 Lemma wp_presample_amplify N z e E α Φ (ε : posreal) L (kwf: kwf N L) prefix suffix :
   TCEq N (Z.to_nat z) →
   to_val e = None →
@@ -1050,6 +1330,33 @@ Proof.
     + iRight. by iFrame.
     + iLeft. erewrite firstn_all; iFrame.
  Unshelve. lia.
+Qed.
+
+Lemma twp_seq_amplify N z e E α Φ (ε : posreal) L (kwf: kwf N L) prefix suffix d :
+  TCEq N (Z.to_nat z) →
+  to_val e = None →
+  L = (length suffix) ->
+  € (pos_to_nn ε) ∗
+  (α ↪ (N; prefix)) ∗
+  ((∃ junk, α ↪ (N; prefix ++ junk ++ suffix) ∨ α ↪ (N; prefix ++ junk) ∗ €(pos_to_nn (εAmp_iter N L d ε kwf)))
+   -∗ WP e @ E [{ Φ }])
+  ⊢ WP e @ E [{ Φ }].
+Proof.
+  iIntros (? ? HL) "(Hcr&Htape&Hwp)".
+  iInduction (d) as [|d'] "IH".
+  - iApply "Hwp".
+    iExists []; rewrite app_nil_r. iRight. iFrame.
+    iApply ec_spend_irrel; last auto.
+    by rewrite /εAmp_iter /pos_to_nn /= Rmult_1_r.
+  - iApply ("IH" with "Hcr Htape").
+    iIntros "[%junk [Hlucky|(Htape&Hcr)]]".
+    + iApply "Hwp". iExists junk; iLeft; iFrame.
+    + iApply twp_presample_amplify; eauto; iFrame.
+      iIntros "[?|[%junk' (Htape&Hcr)]]"; iApply "Hwp".
+      * iExists _; iLeft.
+        rewrite -app_assoc; iFrame.
+      * iExists _; iRight.
+        rewrite -app_assoc -εAmp_iter_cmp; iFrame.
 Qed.
 
 Lemma seq_amplify N z e E α Φ (ε : posreal) L (kwf: kwf N L) prefix suffix d :
@@ -1079,6 +1386,33 @@ Proof.
         rewrite -app_assoc -εAmp_iter_cmp; iFrame.
 Qed.
 
+Lemma twp_presample_planner_pos N z e E α Φ (ε : nonnegreal) prefix suffix :
+  TCEq N (Z.to_nat z) →
+  to_val e = None →
+  (0 < N)%nat ->
+  (0 < (length suffix))%nat ->
+  (0 < ε)%R ->
+  € ε ∗
+  (α ↪ (N; prefix)) ∗
+  ((∃ junk, α ↪ (N; prefix ++ junk ++ suffix)) -∗ WP e @ E [{ Φ }])
+  ⊢ WP e @ E [{ Φ }].
+Proof.
+  iIntros (? ? ? ? Hε) "(Hcr & Htape & Hwp)".
+  remember (length suffix) as L.
+  assert (kwf : kwf N L). { apply mk_kwf; lia. }
+  pose ε' := mkposreal ε.(nonneg) Hε.
+  replace ε with (pos_to_nn ε'); last first.
+  { rewrite /ε' /pos_to_nn. by apply nnreal_ext. }
+  destruct (amplification_depth N L kwf ε') as [d Hdepth].
+  iApply twp_seq_amplify; eauto; iFrame.
+  iIntros "[%junk [?|(_&Hcr)]]".
+  + iApply "Hwp"; iExists _; iFrame.
+  + iExFalso; iApply ec_spend_1; last iFrame.
+    rewrite /pos_to_nn /εAmp_iter /=.
+    replace (nonneg ε) with (pos ε') by auto.
+    done.
+Qed.
+
 
 Lemma presample_planner_pos N z e E α Φ (ε : nonnegreal) prefix suffix :
   TCEq N (Z.to_nat z) →
@@ -1105,6 +1439,27 @@ Proof.
     rewrite /pos_to_nn /εAmp_iter /=.
     replace (nonneg ε) with (pos ε') by auto.
     done.
+Qed.
+
+Lemma twp_presample_planner N z e E α Φ (ε : nonnegreal) prefix suffix :
+  TCEq N (Z.to_nat z) →
+  to_val e = None →
+  (0 < ε)%R ->
+  € ε ∗
+  (α ↪ (S N; prefix)) ∗
+  ((∃ junk, α ↪ (S N; prefix ++ junk ++ suffix)) -∗ WP e @ E [{ Φ }])
+  ⊢ WP e @ E [{ Φ }].
+Proof.
+  iIntros (? ? ?).
+  destruct suffix as [|h R].
+  - iIntros "(_ & Htape & Hwp)".
+    iApply "Hwp".
+    iExists [].
+    do 2 (rewrite -app_nil_end); iFrame.
+  - remember (h :: R) as suffix.
+    iApply (twp_presample_planner_pos); eauto; try lia.
+    + by erewrite Nat2Z.id.
+    + rewrite Heqsuffix cons_length; lia.
 Qed.
 
 Lemma presample_planner N z e E α Φ (ε : nonnegreal) prefix suffix :

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -216,7 +216,7 @@ Qed.
 Lemma wp_rand_err (N : nat) (z : Z) (m : fin (S N)) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_inv(nnreal_nat(N+1))) ∗
-  (∀ x : fin (S N), ⌜(fin_to_nat x) ≠ m⌝ -∗ Φ #x)
+  (∀ x, ⌜x ≠ m⌝ -∗ Φ #x)
   ⊢ WP rand #z @ E {{ Φ }}.
 Proof.
   iIntros. iApply ub_twp_ub_wp'.
@@ -227,7 +227,7 @@ Qed.
 Lemma twp_rand_err_nat (N : nat) (z : Z) (m : nat) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_inv(nnreal_nat(N+1))) ∗
-  (∀ x, ⌜x ≠ m⌝ -∗ Φ #x)
+  (∀ x : fin (S N), ⌜(fin_to_nat x) ≠ m⌝ -∗ Φ #x)
   ⊢ WP rand #z @ E [{ Φ }].
 Proof.
   iIntros (->) "[Herr Hwp]".
@@ -281,7 +281,7 @@ Qed.
 Lemma wp_rand_err_nat (N : nat) (z : Z) (m : nat) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_inv(nnreal_nat(N+1))) ∗
-  (∀ x, ⌜x ≠ m⌝ -∗ Φ #x)
+  (∀ x : fin (S N), ⌜(fin_to_nat x) ≠ m⌝ -∗ Φ #x)
   ⊢ WP rand #z @ E {{ Φ }}.
 Proof.
   iIntros. iApply ub_twp_ub_wp'.
@@ -292,7 +292,7 @@ Qed.
 Lemma twp_rand_err_list_nat (N : nat) (z : Z) (ns : list nat) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_div (nnreal_nat (length ns)) (nnreal_nat(N+1))) ∗
-  (∀ x, ⌜Forall (λ m, x ≠ m) ns⌝ -∗ Φ #x)
+  (∀ x : fin (S N), ⌜Forall (λ m, (fin_to_nat x) ≠ m) ns⌝ -∗ Φ #x)
   ⊢ WP rand #z @ E [{ Φ }].
 Proof.
   iIntros (->) "[Herr Hwp]".
@@ -346,7 +346,7 @@ Qed.
 Lemma wp_rand_err_list_nat (N : nat) (z : Z) (ns : list nat) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_div (nnreal_nat (length ns)) (nnreal_nat(N+1))) ∗
-  (∀ x, ⌜Forall (λ m, x ≠ m) ns⌝ -∗ Φ #x)
+  (∀ x : fin (S N), ⌜Forall (λ m, (fin_to_nat x) ≠ m) ns⌝ -∗ Φ #x)
   ⊢ WP rand #z @ E {{ Φ }}.
 Proof.
   iIntros. iApply ub_twp_ub_wp'.
@@ -356,7 +356,7 @@ Qed.
 Lemma twp_rand_err_list_int (N : nat) (z : Z) (zs : list Z) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_div (nnreal_nat (length zs)) (nnreal_nat(N+1))) ∗
-  (∀ x : Z , ⌜Forall (λ m, x ≠ m) zs⌝ -∗ Φ #x)
+  (∀ x : fin (S N), ⌜Forall (λ m, (Z.of_nat $ fin_to_nat x) ≠ m) zs⌝ -∗ Φ #x)
   ⊢ WP rand #z @ E [{ Φ }].
 Proof.
   iIntros (->) "[Herr Hwp]".
@@ -410,7 +410,7 @@ Qed.
 Lemma wp_rand_err_list_int (N : nat) (z : Z) (zs : list Z) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_div (nnreal_nat (length zs)) (nnreal_nat(N+1))) ∗
-  (∀ x : Z , ⌜Forall (λ m, x ≠ m) zs⌝ -∗ Φ #x)
+  (∀ x : fin (S N), ⌜Forall (λ m, (Z.of_nat $ fin_to_nat x) ≠ m) zs⌝ -∗ Φ #x)
   ⊢ WP rand #z @ E {{ Φ }}.
 Proof.
   iIntros. iApply ub_twp_ub_wp'.
@@ -680,6 +680,34 @@ Proof.
   wp_apply (twp_couple_rand_adv_comp with "[$]"); try done.
   iIntros (?) "H1 H2". iModIntro.
   iApply ("H2" with "[$]").
+Qed.
+
+Lemma twp_couple_rand_adv_comp1 (N : nat) z E Φ (ε1 : nonnegreal) (ε2 : fin (S N) -> nonnegreal) :
+  TCEq N (Z.to_nat z) →
+  SeriesC (λ n, (1 / (S N)) * ε2 n)%R = (nonneg ε1) →
+  [[{ € ε1 }]] rand #z @ E [[{ n, RET #n; € (ε2 n) }]].
+Proof.
+  iIntros (H1 H2).
+  eapply (twp_couple_rand_adv_comp _ _ _ Φ ε1 ε2).
+  - apply H1.
+  - edestruct mean_constraint_ub as [H3 H4].
+    + apply H2.
+    + eexists _; eapply H4.
+  - apply H2.
+Qed.
+
+Lemma wp_couple_rand_adv_comp1 (N : nat) z E Φ (ε1 : nonnegreal) (ε2 : fin (S N) -> nonnegreal) :
+  TCEq N (Z.to_nat z) →
+  SeriesC (λ n, (1 / (S N)) * ε2 n)%R = (nonneg ε1) →
+  {{{ € ε1 }}} rand #z @ E {{{ n, RET #n; € (ε2 n) }}}.
+Proof.
+  iIntros (H1 H2).
+  eapply (wp_couple_rand_adv_comp _ _ _ Φ ε1 ε2).
+  - apply H1.
+  - edestruct mean_constraint_ub as [H3 H4].
+    + apply H2.
+    + eexists _; eapply H4.
+  - apply H2.
 Qed.
 
 (** * Approximate Lifting *)
@@ -1341,10 +1369,10 @@ Qed.
 Lemma twp_seq_amplify N z e E α Φ (ε : posreal) L (kwf: kwf N L) prefix suffix d :
   TCEq N (Z.to_nat z) →
   to_val e = None →
-  L = (length suffix) ->
+  (forall junk, 0 < (length (suffix (prefix ++ junk))) <= L)%nat ->
   € (pos_to_nn ε) ∗
   (α ↪ (N; prefix)) ∗
-  ((∃ junk, α ↪ (N; prefix ++ junk ++ suffix) ∨ α ↪ (N; prefix ++ junk) ∗ €(pos_to_nn (εAmp_iter N L d ε kwf)))
+  ((∃ junk, α ↪ (N; prefix ++ junk ++ (suffix (prefix ++ junk))) ∨ α ↪ (N; prefix ++ junk) ∗ €(pos_to_nn (εAmp_iter N L d ε kwf)))
    -∗ WP e @ E [{ Φ }])
   ⊢ WP e @ E [{ Φ }].
 Proof.
@@ -1357,12 +1385,33 @@ Proof.
   - iApply ("IH" with "Hcr Htape").
     iIntros "[%junk [Hlucky|(Htape&Hcr)]]".
     + iApply "Hwp". iExists junk; iLeft; iFrame.
-    + iApply twp_presample_amplify; eauto; iFrame.
+    + pose L' := (length (suffix (prefix ++ junk))).
+      iApply (twp_presample_amplify _ _ _ _ _ _ _ L'); eauto; iFrame.
       iIntros "[?|[%junk' (Htape&Hcr)]]"; iApply "Hwp".
       * iExists _; iLeft.
         rewrite -app_assoc; iFrame.
       * iExists _; iRight.
         rewrite -app_assoc -εAmp_iter_cmp; iFrame.
+        iApply (ec_spend_le_irrel with "Hcr").
+        rewrite /εAmp /=.
+        apply Rmult_le_compat_l.
+        { apply Rmult_le_pos; [apply Rlt_le, cond_pos | apply pow_le, Rlt_le, k_pos]. }
+        apply Rplus_le_compat_l.
+        rewrite /Rdiv Rmult_1_l Rmult_1_l.
+        apply Rinv_le_contravar.
+        -- apply (Rplus_lt_reg_r 1%R).
+           rewrite /Rminus Rplus_assoc Rplus_opp_l Rplus_0_l Rplus_0_r.
+           apply Rlt_pow_R1.
+           --- apply lt_1_INR; destruct kwf; lia.
+           --- rewrite /L'. by destruct (HL junk).
+        -- apply Rplus_le_compat_r, Rle_pow.
+           --- rewrite S_INR. pose P := (pos_INR N); lra.
+           --- rewrite /L'. by destruct (HL junk).
+  Unshelve.
+    destruct kwf.
+    destruct (HL junk).
+    rewrite /L'.
+    constructor; try lia.
 Qed.
 
 Lemma seq_amplify N z e E α Φ (ε : posreal) L (kwf: kwf N L) prefix suffix d :
@@ -1413,20 +1462,22 @@ Proof.
     constructor; try lia.
 Qed.
 
-Lemma twp_presample_planner_pos N z e E α Φ (ε : nonnegreal) prefix suffix :
+Lemma twp_presample_planner_pos N z e E α Φ (ε : nonnegreal) L prefix suffix :
   TCEq N (Z.to_nat z) →
   to_val e = None →
   (0 < N)%nat ->
-  (0 < (length suffix))%nat ->
+  (forall junk, 0 < (length (suffix (prefix ++ junk))) <= L)%nat ->
   (0 < ε)%R ->
   € ε ∗
   (α ↪ (N; prefix)) ∗
-  ((∃ junk, α ↪ (N; prefix ++ junk ++ suffix)) -∗ WP e @ E [{ Φ }])
+  ((∃ junk, α ↪ (N; prefix ++ junk ++ (suffix (prefix ++ junk)))) -∗ WP e @ E [{ Φ }])
   ⊢ WP e @ E [{ Φ }].
 Proof.
   iIntros (? ? ? ? Hε) "(Hcr & Htape & Hwp)".
-  remember (length suffix) as L.
-  assert (kwf : kwf N L). { apply mk_kwf; lia. }
+  assert (kwf : kwf N L). {
+    apply mk_kwf; try lia.
+    destruct (H2 []) as [H2' H2''].
+    eapply Nat.lt_le_trans; eauto. }
   pose ε' := mkposreal ε.(nonneg) Hε.
   replace ε with (pos_to_nn ε'); last first.
   { rewrite /ε' /pos_to_nn. by apply nnreal_ext. }
@@ -1470,28 +1521,30 @@ Proof.
     done.
 Qed.
 
-Lemma twp_presample_planner N z e E α Φ (ε : nonnegreal) prefix suffix :
+(* general planner rule, with bounded synchronization strings *)
+Lemma twp_presample_planner_sync N z e E α Φ (ε : nonnegreal) L prefix suffix :
   TCEq N (Z.to_nat z) →
   to_val e = None →
   (0 < ε)%R ->
+  (forall junk, 0 < (length (suffix (prefix ++ junk))) <= L)%nat ->
   € ε ∗
   (α ↪ (S N; prefix)) ∗
-  ((∃ junk, α ↪ (S N; prefix ++ junk ++ suffix)) -∗ WP e @ E [{ Φ }])
+  ((∃ junk, α ↪ (S N; prefix ++ junk ++ suffix (prefix ++ junk))) -∗ WP e @ E [{ Φ }])
   ⊢ WP e @ E [{ Φ }].
 Proof.
-  iIntros (? ? ?).
-  destruct suffix as [|h R].
+  iIntros (? ? ? ?).
+  destruct (suffix prefix) as [|h R] eqn:Hsp.
   - iIntros "(_ & Htape & Hwp)".
     iApply "Hwp".
     iExists [].
-    do 2 (rewrite -app_nil_end); iFrame.
-  - remember (h :: R) as suffix.
-    iApply (twp_presample_planner_pos); eauto; try lia.
-    + by erewrite Nat2Z.id.
-    + rewrite Heqsuffix cons_length; lia.
+    rewrite app_nil_r app_assoc app_nil_r Hsp app_nil_r.
+    iFrame.
+  - iApply (twp_presample_planner_pos); eauto; try lia.
+    by erewrite Nat2Z.id.
 Qed.
 
-Lemma presample_planner N z e E α Φ (ε : nonnegreal) prefix suffix :
+(* general planner rule, with bounded synchronization strings *)
+Lemma presample_planner_sync N z e E α Φ (ε : nonnegreal) L prefix suffix :
   TCEq N (Z.to_nat z) →
   to_val e = None →
   (0 < ε)%R ->
@@ -1514,6 +1567,25 @@ Qed.
 
 
 (* classic version *)
+Lemma twp_presample_planner N z e E α Φ (ε : nonnegreal) prefix suffix :
+  TCEq N (Z.to_nat z) →
+  to_val e = None →
+  (0 < ε)%R ->
+  € ε ∗
+  (α ↪ (S N; prefix)) ∗
+  ((∃ junk, α ↪ (S N; prefix ++ junk ++ suffix)) -∗ WP e @ E [{ Φ }])
+  ⊢ WP e @ E [{ Φ }].
+Proof.
+  iIntros (? ? ?) "(Hcr&Htape&Hwp)".
+  destruct suffix as [|] eqn:HS.
+  - iApply "Hwp".
+    iExists [].
+    do 2 rewrite app_nil_r; iFrame.
+  - iApply (twp_presample_planner_sync _ _ _ _ _ _ _ (length suffix) _ (fun _ => suffix)); eauto.
+    + intros; rewrite HS /=. lia.
+    + rewrite HS. iFrame.
+Qed.
+
 Lemma presample_planner N z e E α Φ (ε : nonnegreal) prefix suffix :
   TCEq N (Z.to_nat z) →
   to_val e = None →
@@ -1532,7 +1604,6 @@ Proof.
     + intros; rewrite HS /=. lia.
     + rewrite HS. iFrame.
 Qed.
-
 
 (* pads the junk up to a multiple of blocksize *)
 Definition block_pad N blocksize : list (fin (S (S N))) -> list (fin (S (S N))) :=
@@ -1562,6 +1633,31 @@ Qed.
 
 
 (* version where junk is a mipltple of sample length *)
+Lemma twp_presample_planner_aligned N z e E α Φ (ε : nonnegreal) prefix suffix :
+  TCEq N (Z.to_nat z) →
+  to_val e = None →
+  (0 < ε)%R ->
+  € ε ∗
+  (α ↪ (S N; prefix)) ∗
+  ((∃ junk, α ↪ (S N; prefix ++ junk ++ (block_pad N (length suffix) (prefix ++ junk)) ++ suffix)) -∗ WP e @ E [{ Φ }])
+  ⊢ WP e @ E [{ Φ }].
+Proof.
+  iIntros (? ? ?) "(Hcr&Htape&Hwp)".
+  destruct suffix as [|] eqn:HS.
+  - iApply "Hwp".
+    iExists [].
+    do 2 rewrite app_nil_r; iFrame.
+  - iApply (twp_presample_planner_sync _ _ _ _ _ _ _ (length suffix + length suffix) _ (fun samples => block_pad N (length suffix) samples ++ suffix)); eauto.
+    + intros. split.
+      * rewrite app_length HS /=. lia.
+      * rewrite app_length /=.
+        apply Nat.add_le_mono_r, block_pad_ub.
+        rewrite HS /=. lia.
+    + rewrite HS.
+      (* iFrame is very slow here *)
+      iFrame.
+Qed.
+
 Lemma presample_planner_aligned N z e E α Φ (ε : nonnegreal) prefix suffix :
   TCEq N (Z.to_nat z) →
   to_val e = None →

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -5,6 +5,7 @@ From clutch.prelude Require Import stdpp_ext.
 From clutch.prob_lang Require Import notation tactics metatheory.
 From clutch.prob_lang Require Export lang.
 From clutch.ub_logic Require Export lifting ectx_lifting primitive_laws proofmode seq_amplification.
+From clutch.ub_logic Require Export total_lifting total_ectx_lifting total_primitive_laws.
 
 Section metatheory.
 
@@ -156,14 +157,14 @@ Section rules.
   Implicit Types v : val.
   Implicit Types l : loc.
 
-Lemma wp_rand_err (N : nat) (z : Z) (m : fin (S N)) E Φ :
+Lemma twp_rand_err (N : nat) (z : Z) (m : fin (S N)) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_inv(nnreal_nat(N+1))) ∗
   (∀ x, ⌜x ≠ m⌝ -∗ Φ #x)
-  ⊢ WP rand #z @ E {{ Φ }}.
+  ⊢ WP rand #z @ E [{ Φ }].
 Proof.
   iIntros (->) "[Herr Hwp]".
-  iApply wp_lift_step_fupd_exec_ub; [done|].
+  iApply twp_lift_step_fupd_exec_ub; [done|].
   iIntros (σ1 ε) "[Hσ Hε]".
   iApply fupd_mask_intro; [set_solver|].
   iIntros "Hclose'".
@@ -202,14 +203,24 @@ Proof.
   destruct H as (n & Hn1 & [=]); simplify_eq.
   iPoseProof (ec_decrease_supply) as "Hdec".
   iSpecialize ("Hdec" with "Hε Herr"); eauto.
-  do 2 iModIntro.
+  iModIntro.
   iMod "Hclose'".
   iMod "Hdec".
   iFrame.
   iModIntro.
-  iApply ub_wp_value.
+  iApply ub_twp_value.
   iApply "Hwp".
   done.
+Qed.
+
+Lemma wp_rand_err (N : nat) (z : Z) (m : fin (S N)) E Φ :
+  TCEq N (Z.to_nat z) →
+  € (nnreal_inv(nnreal_nat(N+1))) ∗
+  (∀ x, ⌜x ≠ m⌝ -∗ Φ #x)
+  ⊢ WP rand #z @ E {{ Φ }}.
+Proof.
+  iIntros. iApply ub_twp_ub_wp'.
+  iApply (twp_rand_err with "[$]").
 Qed.
 
 

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -224,14 +224,14 @@ Proof.
 Qed.
 
 
-Lemma wp_rand_err_nat (N : nat) (z : Z) (m : nat) E Φ :
+Lemma twp_rand_err_nat (N : nat) (z : Z) (m : nat) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_inv(nnreal_nat(N+1))) ∗
   (∀ x, ⌜x ≠ m⌝ -∗ Φ #x)
-  ⊢ WP rand #z @ E {{ Φ }}.
+  ⊢ WP rand #z @ E [{ Φ }].
 Proof.
   iIntros (->) "[Herr Hwp]".
-  iApply wp_lift_step_fupd_exec_ub; [done|].
+  iApply twp_lift_step_fupd_exec_ub; [done|].
   iIntros (σ1 ε) "[Hσ Hε]".
   iApply fupd_mask_intro; [set_solver|].
   iIntros "Hclose'".
@@ -268,25 +268,35 @@ Proof.
   destruct H as (n & Hn1 & [=]); simplify_eq.
   iPoseProof (ec_decrease_supply) as "Hdec".
   iSpecialize ("Hdec" with "Hε Herr"); eauto.
-  do 2 iModIntro.
+  iModIntro.
   iMod "Hclose'".
   iMod "Hdec".
   iFrame.
   iModIntro.
-  iApply ub_wp_value.
+  iApply ub_twp_value.
   iApply "Hwp".
   done.
 Qed.
 
+Lemma wp_rand_err_nat (N : nat) (z : Z) (m : nat) E Φ :
+  TCEq N (Z.to_nat z) →
+  € (nnreal_inv(nnreal_nat(N+1))) ∗
+  (∀ x, ⌜x ≠ m⌝ -∗ Φ #x)
+  ⊢ WP rand #z @ E {{ Φ }}.
+Proof.
+  iIntros. iApply ub_twp_ub_wp'.
+  iApply (twp_rand_err_nat with "[$]").
+Qed.
 
-Lemma wp_rand_err_list_nat (N : nat) (z : Z) (ns : list nat) E Φ :
+
+Lemma twp_rand_err_list_nat (N : nat) (z : Z) (ns : list nat) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_div (nnreal_nat (length ns)) (nnreal_nat(N+1))) ∗
   (∀ x, ⌜Forall (λ m, x ≠ m) ns⌝ -∗ Φ #x)
-  ⊢ WP rand #z @ E {{ Φ }}.
+  ⊢ WP rand #z @ E [{ Φ }].
 Proof.
   iIntros (->) "[Herr Hwp]".
-  iApply wp_lift_step_fupd_exec_ub; [done|].
+  iApply twp_lift_step_fupd_exec_ub; [done|].
   iIntros (σ1 ε) "[Hσ Hε]".
   iApply fupd_mask_intro; [set_solver|].
   iIntros "Hclose'".
@@ -323,25 +333,34 @@ Proof.
   destruct H as (n & Hn1 & [=]); simplify_eq.
   iPoseProof (ec_decrease_supply) as "Hdec".
   iSpecialize ("Hdec" with "Hε Herr"); eauto.
-  do 2 iModIntro.
+  iModIntro.
   iMod "Hclose'".
   iMod "Hdec".
   iFrame.
   iModIntro.
-  iApply ub_wp_value.
+  iApply ub_twp_value.
   iApply "Hwp".
   done.
 Qed.
 
+Lemma wp_rand_err_list_nat (N : nat) (z : Z) (ns : list nat) E Φ :
+  TCEq N (Z.to_nat z) →
+  € (nnreal_div (nnreal_nat (length ns)) (nnreal_nat(N+1))) ∗
+  (∀ x, ⌜Forall (λ m, x ≠ m) ns⌝ -∗ Φ #x)
+  ⊢ WP rand #z @ E {{ Φ }}.
+Proof.
+  iIntros. iApply ub_twp_ub_wp'.
+  by iApply (twp_rand_err_list_nat).
+Qed.
 
-Lemma wp_rand_err_list_int (N : nat) (z : Z) (zs : list Z) E Φ :
+Lemma twp_rand_err_list_int (N : nat) (z : Z) (zs : list Z) E Φ :
   TCEq N (Z.to_nat z) →
   € (nnreal_div (nnreal_nat (length zs)) (nnreal_nat(N+1))) ∗
   (∀ x : Z , ⌜Forall (λ m, x ≠ m) zs⌝ -∗ Φ #x)
-  ⊢ WP rand #z @ E {{ Φ }}.
+  ⊢ WP rand #z @ E [{ Φ }].
 Proof.
   iIntros (->) "[Herr Hwp]".
-  iApply wp_lift_step_fupd_exec_ub; [done|].
+  iApply twp_lift_step_fupd_exec_ub; [done|].
   iIntros (σ1 ε) "[Hσ Hε]".
   iApply fupd_mask_intro; [set_solver|].
   iIntros "Hclose'".
@@ -378,14 +397,24 @@ Proof.
   destruct H as (n & Hn1 & [=]); simplify_eq.
   iPoseProof (ec_decrease_supply) as "Hdec".
   iSpecialize ("Hdec" with "Hε Herr"); eauto.
-  do 2 iModIntro.
+  iModIntro.
   iMod "Hclose'".
   iMod "Hdec".
   iFrame.
   iModIntro.
-  iApply ub_wp_value.
+  iApply ub_twp_value.
   iApply "Hwp".
   done.
+Qed.
+
+Lemma wp_rand_err_list_int (N : nat) (z : Z) (zs : list Z) E Φ :
+  TCEq N (Z.to_nat z) →
+  € (nnreal_div (nnreal_nat (length zs)) (nnreal_nat(N+1))) ∗
+  (∀ x : Z , ⌜Forall (λ m, x ≠ m) zs⌝ -∗ Φ #x)
+  ⊢ WP rand #z @ E {{ Φ }}.
+Proof.
+  iIntros. iApply ub_twp_ub_wp'.
+  by iApply twp_rand_err_list_int.
 Qed.
 
 (* FIXME: where should this go (if anywhere?) *)
@@ -422,14 +451,14 @@ Proof.
 Qed.
 
 
-Lemma wp_couple_rand_adv_comp (N : nat) z E Φ (ε1 : nonnegreal) (ε2 : fin (S N) -> nonnegreal) :
+Lemma twp_couple_rand_adv_comp (N : nat) z E Φ (ε1 : nonnegreal) (ε2 : fin (S N) -> nonnegreal) :
   TCEq N (Z.to_nat z) →
   (exists r, ∀ n, (ε2 n <= r)%R) →
   SeriesC (λ n, (1 / (S N)) * ε2 n)%R = (nonneg ε1) →
-  {{{ € ε1 }}} rand #z @ E {{{ n, RET #n; € (ε2 n) }}}.
+  [[{ € ε1 }]] rand #z @ E [[{ n, RET #n; € (ε2 n) }]].
 Proof.
   iIntros (-> (r & Hε2) Hε1 Ψ) "Herr HΨ".
-  iApply wp_lift_step_fupd_exec_ub; [done|].
+  iApply twp_lift_step_fupd_exec_ub; [done|].
   iIntros (σ1 ε_now) "[Hσ Hε]".
   iApply fupd_mask_intro; [set_solver|].
   iIntros "Hclose'".
@@ -627,7 +656,7 @@ Proof.
     apply fin_to_nat_lt.
   }
   iMod (ec_decrease_supply with "Hε Herr") as "Hε2".
-  do 2 iModIntro.
+  iModIntro.
   iMod "Hclose'".
   iFrame.
   iMod (ec_increase_supply _ (ε2 (nat_to_fin l)) with "Hε2") as "[Hε2 Hfoo]".
@@ -640,7 +669,18 @@ Proof.
   reflexivity.
 Qed.
 
-
+Lemma wp_couple_rand_adv_comp (N : nat) z E Φ (ε1 : nonnegreal) (ε2 : fin (S N) -> nonnegreal) :
+  TCEq N (Z.to_nat z) →
+  (exists r, ∀ n, (ε2 n <= r)%R) →
+  SeriesC (λ n, (1 / (S N)) * ε2 n)%R = (nonneg ε1) →
+  {{{ € ε1 }}} rand #z @ E {{{ n, RET #n; € (ε2 n) }}}.
+Proof.
+  iIntros.
+  iApply (ub_twp_ub_wp_step' with "[$]").
+  wp_apply (twp_couple_rand_adv_comp with "[$]"); try done.
+  iIntros (?) "H1 H2". iModIntro.
+  iApply ("H2" with "[$]").
+Qed.
 
 (** * Approximate Lifting *)
 Lemma ub_lift_state (N : nat) 𝜎 𝛼 ns :

--- a/theories/ub_logic/ub_total_weakestpre.v
+++ b/theories/ub_logic/ub_total_weakestpre.v
@@ -254,6 +254,13 @@ Section ub_twp.
     iModIntro. iFrame. iApply "IH". done.
   Qed.
 
+  Lemma ub_twp_ub_wp' E e Φ : WP e @ E [{ Φ }] -∗ WP e @ E {{ Φ }}.
+  Proof.
+    iIntros "H".
+    iApply ub_twp_ub_wp.
+    by destruct wp_default, twp_default.
+  Qed. 
+
   (** * Derived rules *)
   Lemma ub_twp_mono s E e Φ Ψ :
     (∀ v, Φ v ⊢ Ψ v) → WP e @ s; E [{ Φ }] ⊢ WP e @ s; E [{ Ψ }].

--- a/theories/ub_logic/ub_total_weakestpre.v
+++ b/theories/ub_logic/ub_total_weakestpre.v
@@ -103,6 +103,13 @@ Section ub_twp.
     by intros Φ Φ' ?; apply equiv_dist=>n; apply ub_twp_ne=>v; apply equiv_dist.
   Qed.
 
+  Lemma ub_twp_ind' E s Ψ :
+  (∀ n e, Proper (pointwise_relation _ (dist n) ==> dist n) (Ψ E e)) →
+  □ (∀ e Φ, ub_twp_pre (λ E e Φ, Ψ E e Φ ∧ WP e @ s; E [{ Φ }]) E e Φ -∗ Ψ E e Φ) -∗
+  ∀ e Φ, WP e @ s; E [{ Φ }] -∗ Ψ E e Φ.
+  Proof.
+    Admitted.
+  
   Lemma ub_twp_value_fupd' s E Φ v : WP of_val v @ s; E [{ Φ }] ⊣⊢ |={E}=> Φ v.
   Proof. rewrite ub_twp_unfold /ub_twp_pre to_of_val. auto. Qed.
 

--- a/theories/ub_logic/ub_total_weakestpre.v
+++ b/theories/ub_logic/ub_total_weakestpre.v
@@ -259,7 +259,26 @@ Section ub_twp.
     iIntros "H".
     iApply ub_twp_ub_wp.
     by destruct wp_default, twp_default.
-  Qed. 
+  Qed.
+
+  Lemma ub_twp_ub_wp_step s E e P Φ :
+    TCEq (to_val e) None →
+    ▷ P -∗
+    WP e @ s; E [{ v, P ={E}=∗ Φ v }] -∗ WP e @ s; E {{ Φ }}.
+  Proof.
+    iIntros (?) "HP Hwp".
+    iApply (ub_wp_step_fupd _ _ E _ P with "[HP]"); [auto..|]. by iApply ub_twp_ub_wp.
+  Qed.
+
+  Lemma ub_twp_ub_wp_step' E e P Φ :
+    TCEq (to_val e) None →
+    ▷ P -∗
+    WP e @ E [{ v, P ={E}=∗ Φ v }] -∗ WP e @ E {{ Φ }}.
+  Proof.
+    iIntros (?) "HP Hwp".
+    iApply (ub_wp_step_fupd _ _ E _ P with "[HP]"); [auto..|]. by iApply ub_twp_ub_wp'.
+  Qed.
+  
 
   (** * Derived rules *)
   Lemma ub_twp_mono s E e Φ Ψ :

--- a/theories/ub_logic/ub_total_weakestpre.v
+++ b/theories/ub_logic/ub_total_weakestpre.v
@@ -1,0 +1,16 @@
+From clutch.ub_logic Require Export ub_weakestpre.
+
+Import uPred.
+
+(** * The total weakest precondition *)
+Definition ub_twp_pre `{!irisGS Λ Σ}
+  (wp : coPset -d> expr Λ -d> (val Λ -d> iPropO Σ) -d> iPropO Σ) :
+    coPset -d> expr Λ -d> (val Λ -d> iPropO Σ) -d> iPropO Σ := λ E e1 Φ,
+  match to_val e1 with
+  | Some v => |={E}=> Φ v
+  | None => ∀ σ1 ε,
+      state_interp σ1 ∗ err_interp ε ={E,∅}=∗
+      exec_ub e1 σ1 (λ ε2 '(e2, σ2),
+        |={∅,E}=> state_interp σ2 ∗ err_interp ε2 ∗ wp E e2 Φ) ε
+end%I.
+

--- a/theories/ub_logic/ub_total_weakestpre.v
+++ b/theories/ub_logic/ub_total_weakestpre.v
@@ -111,7 +111,7 @@ Section ub_twp.
     iIntros (Hp) "#IH". iIntros (e Φ) "Hwp".
     iRevert "IH".
     iApply (ub_twp_ind _ (λ E e Φ, _) with "[][$]").
-    - admit.
+    - intros. intros ???. repeat f_equiv.
     - iModIntro.
       clear. iIntros (e E Φ) "H #IH".
       iApply "IH".
@@ -125,7 +125,7 @@ Section ub_twp.
       iFrame. iSplit.
       { by iApply "H". }
       by iDestruct "H" as "[_?]".
-    Admitted.
+  Qed.
   
   Lemma ub_twp_value_fupd' s E Φ v : WP of_val v @ s; E [{ Φ }] ⊣⊢ |={E}=> Φ v.
   Proof. rewrite ub_twp_unfold /ub_twp_pre to_of_val. auto. Qed.

--- a/theories/ub_logic/ub_total_weakestpre.v
+++ b/theories/ub_logic/ub_total_weakestpre.v
@@ -126,6 +126,31 @@ Section ub_twp.
       { by iApply "H". }
       by iDestruct "H" as "[_?]".
   Qed.
+
+  Lemma ub_twp_ind_simple E s Ψ Φ e:
+  (∀ n e, Proper (dist n) (Ψ e)) →
+  □ (∀ e, ub_twp_pre (λ _ e _, Ψ e) E e Φ -∗ Ψ e) -∗
+  WP e @ s; E [{ Φ }] -∗ Ψ e.
+  Proof.
+    iIntros (HΨ) "#IH Htwp".
+    iRevert "IH".
+    iApply (ub_twp_ind _ (λ E e Φ, _)  with "[]Htwp").
+    { intros. intros ???.
+      rewrite /ub_twp_pre. repeat f_equiv.
+    }
+    clear.
+    iModIntro.
+    iIntros (e E Φ) "H #IH".
+    iApply "IH".
+    rewrite {2 4}/ub_twp_pre. case_match; first done.
+    iIntros (σ ε) "[Hs He]".
+    iMod ("H" with "[$]") as "H".
+    iModIntro.
+    iApply (exec_ub_mono_pred with "[]H").
+    iIntros ([] []) "H".
+    iMod "H". iModIntro. iDestruct "H" as "(?&?&H)".
+    iFrame. iApply "H". done.
+  Qed.
   
   Lemma ub_twp_value_fupd' s E Φ v : WP of_val v @ s; E [{ Φ }] ⊣⊢ |={E}=> Φ v.
   Proof. rewrite ub_twp_unfold /ub_twp_pre to_of_val. auto. Qed.

--- a/theories/ub_logic/ub_total_weakestpre.v
+++ b/theories/ub_logic/ub_total_weakestpre.v
@@ -104,10 +104,27 @@ Section ub_twp.
   Qed.
 
   Lemma ub_twp_ind' E s Ψ :
-  (∀ n e, Proper (pointwise_relation _ (dist n) ==> dist n) (Ψ E e)) →
-  □ (∀ e Φ, ub_twp_pre (λ E e Φ, Ψ E e Φ ∧ WP e @ s; E [{ Φ }]) E e Φ -∗ Ψ E e Φ) -∗
-  ∀ e Φ, WP e @ s; E [{ Φ }] -∗ Ψ E e Φ.
+  (∀ n e, Proper (pointwise_relation _ (dist n) ==> dist n) (Ψ e)) →
+  □ (∀ e Φ, ub_twp_pre (λ E e Φ, Ψ e Φ ∧ WP e @ s; E [{ Φ }]) E e Φ -∗ Ψ e Φ) -∗
+  ∀ e Φ, WP e @ s; E [{ Φ }] -∗ Ψ e Φ.
   Proof.
+    iIntros (Hp) "#IH". iIntros (e Φ) "Hwp".
+    iRevert "IH".
+    iApply (ub_twp_ind _ (λ E e Φ, _) with "[][$]").
+    - admit.
+    - iModIntro.
+      clear. iIntros (e E Φ) "H #IH".
+      iApply "IH".
+      rewrite {2 4}/ub_twp_pre. case_match; first done.
+      iIntros (σ ε) "[Hs He]".
+      iMod ("H" with "[$]") as "H".
+      iModIntro.
+      iApply (exec_ub_mono_pred with "[]H").
+      iIntros ([] []) "H".
+      iMod "H". iModIntro. iDestruct "H" as "(?&?&H)".
+      iFrame. iSplit.
+      { by iApply "H". }
+      by iDestruct "H" as "[_?]".
     Admitted.
   
   Lemma ub_twp_value_fupd' s E Φ v : WP of_val v @ s; E [{ Φ }] ⊣⊢ |={E}=> Φ v.

--- a/theories/ub_logic/ub_total_weakestpre.v
+++ b/theories/ub_logic/ub_total_weakestpre.v
@@ -1,3 +1,4 @@
+From iris.proofmode Require Import base proofmode.
 From clutch.ub_logic Require Export ub_weakestpre.
 
 Import uPred.
@@ -14,3 +15,293 @@ Definition ub_twp_pre `{!irisGS Λ Σ}
         |={∅,E}=> state_interp σ2 ∗ err_interp ε2 ∗ wp E e2 Φ) ε
 end%I.
 
+Local Lemma ub_twp_pre_mono `{!irisGS Λ Σ}
+  (wp1 wp2 : coPset -d> expr Λ -d> (val Λ -d> iPropO Σ) -d> iPropO Σ) :
+  ⊢ (□ ∀ E e Φ, wp1 E e Φ -∗ wp2 E e Φ) →
+    ∀ E e Φ, ub_twp_pre wp1 E e Φ -∗ ub_twp_pre wp2 E e Φ.
+Proof.
+  iIntros "#H".
+  iIntros (E e Φ) "Hwp". rewrite /ub_twp_pre.
+  case_match; first done.
+  iIntros (σ ε) "He". iMod ("Hwp" with "He") as "Hwp".
+  iModIntro. iApply (exec_ub_mono_pred with "[][$Hwp]").
+  iIntros (ε' [e' s]) "He".
+  iApply (fupd_wand_l with "[H He]").
+  iFrame. iIntros "[?[??]]". iFrame.
+  by iApply "H".
+Qed.
+
+Local Definition ub_twp_pre' `{!irisGS Λ Σ} :
+  (prodO (prodO (leibnizO coPset) (exprO Λ)) (val Λ -d> iPropO Σ) → iPropO Σ) →
+  prodO (prodO (leibnizO coPset) (exprO Λ)) (val Λ -d> iPropO Σ) → iPropO Σ :=
+  uncurry3 ∘ ub_twp_pre ∘ curry3.
+
+Local Instance ub_twp_pre_mono' `{!irisGS Λ Σ} :
+  BiMonoPred (ub_twp_pre').
+Proof.
+  constructor.
+  - iIntros (wp1 wp2 ??) "#H"; iIntros ([[E e1] Φ]); iRevert (E e1 Φ).
+    iApply ub_twp_pre_mono. iIntros "!>" (E e Φ). iApply ("H" $! (E,e,Φ)).
+  - intros wp Hwp n [[E1 e1] Φ1] [[E2 e2] Φ2]
+      [[?%leibniz_equiv ?%leibniz_equiv] ?]; simplify_eq/=.
+    rewrite /curry3 /ub_twp_pre. do 7 (f_equiv).
+    rewrite /exec_ub /exec_ub'.
+    f_equiv.
+    intros Φ e. unfold exec_ub_pre.
+    do 21 f_equiv.
+    { by apply pair_ne. }
+    do 2 f_equiv.
+    by apply pair_ne.
+Qed.
+
+Local Definition ub_twp_def `{!irisGS Λ Σ} : Twp (iProp Σ) (expr Λ) (val Λ) () :=
+  {| twp := λ (_ : ()) E e Φ, (bi_least_fixpoint ub_twp_pre') (E, e, Φ); twp_default := () |}.
+Local Definition ub_twp_aux : seal (@ub_twp_def). Proof. by eexists. Qed.
+Definition ub_twp' := ub_twp_aux.(unseal).
+Global Arguments ub_twp' {Λ Σ _}.
+Global Existing Instance ub_twp'.
+Local Lemma ub_twp_unseal `{!irisGS Λ Σ} : twp = (@ub_twp_def Λ Σ _).(twp).
+Proof. rewrite -ub_twp_aux.(seal_eq) //. Qed.
+
+Section ub_twp.
+  Context `{!irisGS Λ Σ}.
+  Implicit Types P : iProp Σ.
+  Implicit Types Φ : val Λ → iProp Σ.
+  Implicit Types v : val Λ.
+  Implicit Types e : expr Λ.
+  Implicit Types σ : state Λ.
+  Implicit Types ρ : cfg Λ.
+  Implicit Types ε : R.
+
+  (* Total Wekaest pre *)
+  Lemma ub_twp_unfold s E e Φ : WP e @ s; E [{ Φ }] ⊣⊢ ub_twp_pre (twp (PROP:=iProp Σ) s) E e Φ.
+  Proof. rewrite ub_twp_unseal /ub_twp_def. simpl. rewrite least_fixpoint_unfold. done. Qed.
+
+  Lemma ub_twp_ind s Ψ :
+  (∀ n E e, Proper (pointwise_relation _ (dist n) ==> dist n) (Ψ E e)) →
+  □ (∀ e E Φ, ub_twp_pre (λ E e Φ, Ψ E e Φ ∧ WP e @ s; E [{ Φ }]) E e Φ -∗ Ψ E e Φ) -∗
+  ∀ e E Φ, WP e @ s; E [{ Φ }] -∗ Ψ E e Φ.
+  Proof.
+    iIntros (HΨ). iIntros "#IH" (e E Φ) "H". rewrite ub_twp_unseal.
+    set (Ψ' := uncurry3 Ψ :
+           prodO (prodO (leibnizO coPset) (exprO Λ)) (val Λ -d> iPropO Σ) → iPropO Σ).
+    assert (NonExpansive Ψ').
+    { intros n [[E1 e1] Φ1] [[E2 e2] Φ2]
+        [[?%leibniz_equiv ?%leibniz_equiv] ?]; simplify_eq/=. by apply HΨ. }
+    iApply (least_fixpoint_ind _ Ψ' with "[] H").
+    iIntros "!>" ([[??] ?]) "H". by iApply "IH".
+  Qed.
+
+  Global Instance ub_twp_ne s E e n :
+    Proper (pointwise_relation _ (dist n) ==> dist n) (twp (PROP:=iProp Σ) s E e).
+  Proof.
+    intros Φ1 Φ2 HΦ. rewrite !ub_twp_unseal. by apply (least_fixpoint_ne _), pair_ne, HΦ.
+  Qed.
+  Global Instance ub_twp_proper s E e :
+    Proper (pointwise_relation _ (≡) ==> (≡)) (twp (PROP:=iProp Σ) s E e).
+  Proof.
+    by intros Φ Φ' ?; apply equiv_dist=>n; apply ub_twp_ne=>v; apply equiv_dist.
+  Qed.
+
+  Lemma ub_twp_value_fupd' s E Φ v : WP of_val v @ s; E [{ Φ }] ⊣⊢ |={E}=> Φ v.
+  Proof. rewrite ub_twp_unfold /ub_twp_pre to_of_val. auto. Qed.
+
+  Lemma ub_twp_strong_mono s1 s2 E1 E2 e Φ Ψ :
+    E1 ⊆ E2 →
+    WP e @ s1; E1 [{ Φ }] -∗ (∀ v, Φ v ={E2}=∗ Ψ v) -∗ WP e @ s2; E2 [{ Ψ }].
+  Proof.
+    iIntros (HE) "H HΦ". iRevert (E2 Ψ HE) "HΦ"; iRevert (e E1 Φ) "H".
+    iApply ub_twp_ind; first solve_proper.
+    iIntros "!>" (e E1 Φ) "IH"; iIntros (E2 Ψ HE) "HΦ".
+    rewrite !ub_twp_unfold /ub_twp_pre. destruct (to_val e) as [v|] eqn:?.
+    { iApply ("HΦ" with "[> -]"). by iApply (fupd_mask_mono E1 _). }    
+    iIntros (σ1 ε1) "[Hs He]".
+    iMod (fupd_mask_subseteq E1) as "Hclose"; first done.
+    iMod ("IH" with "[$Hs $He]") as "IH".
+    iModIntro.
+    iApply (exec_ub_mono_pred with "[Hclose HΦ] IH").
+    iIntros (ε [e' s]) "H".
+    iMod "H". iMod "Hclose". iModIntro.
+    iDestruct "H" as "[Hs[He Hk]]".
+    iFrame. by iApply "Hk".
+  Qed.
+
+  
+  Lemma fupd_ub_twp s E e Φ : (|={E}=> WP e @ s; E [{ Φ }]) ⊢ WP e @ s; E [{ Φ }].
+  Proof.
+    rewrite ub_twp_unfold /ub_twp_pre. iIntros "H". destruct (to_val e) as [v|] eqn:?.
+    { by iMod "H". }
+    iIntros (s' ε) "[Hs He]".
+    iMod "H". iApply "H". iFrame.
+  Qed.
+  Lemma ub_twp_fupd s E e Φ : WP e @ s; E [{ v, |={E}=> Φ v }] ⊢ WP e @ s; E [{ Φ }].
+  Proof. iIntros "H". iApply (ub_twp_strong_mono with "H"); auto. Qed.
+
+  Lemma ub_twp_atomic s E1 E2 e Φ `{!Atomic StronglyAtomic e} :
+    (|={E1,E2}=> WP e @ s; E2 [{ v, |={E2,E1}=> Φ v }]) ⊢ WP e @ s; E1 [{ Φ }].
+  Proof.
+    iIntros "H". rewrite !ub_twp_unfold /ub_twp_pre /=.
+    destruct (to_val e) as [v|] eqn:He.
+    { by iDestruct "H" as ">>> $". }
+    iIntros (σ1 ε) "[Hs He]". iMod "H". iMod ("H" $! σ1 ε with "[$Hs $He]") as "H".
+  iModIntro. iApply (exec_ub_strong_mono with "[][]H"); [done|].
+  iIntros (e2 σ2 ε2) "([%σ' %Hstep]&H)".
+  iMod "H" as "(Hσ&Hε&Hwp)".
+  rewrite !ub_twp_unfold /ub_twp_pre.
+  destruct (to_val e2) as [?|] eqn:He2.
+    + iFrame. do 2 (iMod "Hwp"). by do 2 iModIntro.
+    + iMod ("Hwp" $! _ _ with "[Hσ Hε]") as "Hwp"; [iFrame|].
+      specialize (atomic _ _ _ Hstep) as Hatomic. (* key step *)
+      destruct Hatomic.
+      congruence. (* how do we do this "by hand"? Not obvious to me *)
+  Qed.
+
+  Lemma ub_twp_bind K `{!LanguageCtx K} s E e Φ :
+    WP e @ s; E [{ v, WP K (of_val v) @ s; E [{ Φ }] }] ⊢ WP K e @ s; E [{ Φ }].
+  Proof.
+    revert Φ. cut (∀ Φ', WP e @ s; E [{ Φ' }] -∗ ∀ Φ,
+                     (∀ v, Φ' v -∗ WP K (of_val v) @ s; E [{ Φ }]) -∗ WP K e @ s; E [{ Φ }]).
+    { iIntros (help Φ) "H". iApply (help with "H"); auto. }
+    iIntros (Φ') "H". iRevert (e E Φ') "H". iApply ub_twp_ind; first solve_proper.
+    iIntros "!>" (e E1 Φ') "IH". iIntros (Φ) "HΦ".
+    rewrite /ub_twp_pre. destruct (to_val e) as [v|] eqn:He.
+    { apply of_to_val in He as <-. iApply fupd_ub_twp. by iApply "HΦ". }
+    rewrite ub_twp_unfold /ub_twp_pre fill_not_val //.
+    iIntros (σ1 ε1) "[Hσ Hε]". iMod ("IH" with "[$]") as "IH".
+    iModIntro.
+    iApply exec_ub_bind; [done|].
+    iApply (exec_ub_mono with "[][HΦ][$]"); first done.
+    iIntros (ε [e' σ]) "H".
+    iMod "H". iModIntro. iDestruct "H" as "[?[?K]]".
+    iFrame. by iApply "K".
+  Qed.
+  
+  (* Lemma ub_twp_bind_inv K `{!LanguageCtx K} s E e Φ : *)
+  (*   WP K e @ s; E [{ Φ }] -∗ WP e @ s; E [{ v, WP K (of_val v) @ s; E [{ Φ }] }]. *)
+  (* Proof. *)
+  (*   iIntros "H". remember (K e) as e' eqn:He'. *)
+  (*   iRevert (e He'). iRevert (e' E Φ) "H". iApply ub_twp_ind; first solve_proper. *)
+  (*   iIntros "!>" (e' E1 Φ) "IH". iIntros (e ->). *)
+  (*   rewrite !ub_twp_unfold {2}/ub_twp_pre. destruct (to_val e) as [v|] eqn:He. *)
+  (*   { iModIntro. apply of_to_val in He as <-. rewrite !ub_twp_unfold. *)
+  (*     iApply (ub_twp_pre_mono with "[] IH"). by iIntros "!>" (E e Φ') "[_ ?]". } *)
+  (*   rewrite /ub_twp_pre fill_not_val //. *)
+  (*   iIntros (σ ε) "[Hσ Hε]". *)
+  (*   iMod ("IH" with "[$Hσ $Hε]") as "H". *)
+  (*   iModIntro. *)
+  (*   iApply (exec_ub_mono with "[][][H]"). *)
+  (*   { done. } *)
+  (* Admitted. *)
+
+  Lemma ub_twp_ub_wp s E e Φ : WP e @ s; E [{ Φ }] -∗ WP e @ s; E {{ Φ }}.
+  Proof.
+    iIntros "H". iLöb as "IH" forall (E e Φ).
+    rewrite ub_wp_unfold ub_twp_unfold /ub_wp_pre /ub_twp_pre. destruct (to_val e) as [v|]=>//=.
+    iIntros (σ1 ε) "[Hσ Hε]". iMod ("H" with "[$Hσ $Hε]") as "H".
+    iIntros "!>".
+    iApply exec_ub_mono_pred; last iFrame.
+    iIntros (ε' [e' s']).
+    iIntros "H". iNext. iMod "H" as "[?[?H]]".
+    iModIntro. iFrame. iApply "IH". done.
+  Qed.
+
+  (** * Derived rules *)
+  Lemma ub_twp_mono s E e Φ Ψ :
+    (∀ v, Φ v ⊢ Ψ v) → WP e @ s; E [{ Φ }] ⊢ WP e @ s; E [{ Ψ }].
+  Proof.
+    iIntros (HΦ) "H"; iApply (ub_twp_strong_mono with "H"); auto.
+    iIntros (v) "?". by iApply HΦ.
+  Qed.
+  Lemma ub_twp_mask_mono s E1 E2 e Φ :
+    E1 ⊆ E2 → WP e @ s; E1 [{ Φ }] -∗ WP e @ s; E2 [{ Φ }].
+  Proof. iIntros (?) "H"; iApply (ub_twp_strong_mono with "H"); auto. Qed.
+  Global Instance ub_twp_mono' s E e :
+    Proper (pointwise_relation _ (⊢) ==> (⊢)) (twp (PROP:=iProp Σ) s E e).
+  Proof. by intros Φ Φ' ?; apply ub_twp_mono. Qed.
+
+  Lemma ub_twp_value_fupd s E Φ e v : IntoVal e v → WP e @ s; E [{ Φ }] ⊣⊢ |={E}=> Φ v.
+  Proof. intros <-. by apply ub_twp_value_fupd'. Qed.
+  Lemma ub_twp_value' s E Φ v : Φ v ⊢ WP (of_val v) @ s; E [{ Φ }].
+  Proof. rewrite ub_twp_value_fupd'. auto. Qed.
+  Lemma ub_twp_value s E Φ e v : IntoVal e v → Φ v ⊢ WP e @ s; E [{ Φ }].
+  Proof. intros <-. apply ub_twp_value'. Qed.
+
+  Lemma ub_twp_frame_l s E e Φ R : R ∗ WP e @ s; E [{ Φ }] ⊢ WP e @ s; E [{ v, R ∗ Φ v }].
+  Proof. iIntros "[? H]". iApply (ub_twp_strong_mono with "H"); auto with iFrame. Qed.
+  Lemma ub_twp_frame_r s E e Φ R : WP e @ s; E [{ Φ }] ∗ R ⊢ WP e @ s; E [{ v, Φ v ∗ R }].
+  Proof. iIntros "[H ?]". iApply (ub_twp_strong_mono with "H"); auto with iFrame. Qed.
+
+  Lemma ub_twp_wand s E e Φ Ψ :
+    WP e @ s; E [{ Φ }] -∗ (∀ v, Φ v -∗ Ψ v) -∗ WP e @ s; E [{ Ψ }].
+  Proof.
+    iIntros "H HΦ". iApply (ub_twp_strong_mono with "H"); auto.
+    iIntros (?) "?". by iApply "HΦ".
+  Qed.
+  Lemma ub_twp_wand_l s E e Φ Ψ :
+    (∀ v, Φ v -∗ Ψ v) ∗ WP e @ s; E [{ Φ }] -∗ WP e @ s; E [{ Ψ }].
+  Proof. iIntros "[H Hwp]". iApply (ub_twp_wand with "Hwp H"). Qed.
+  Lemma ub_twp_wand_r s E e Φ Ψ :
+    WP e @ s; E [{ Φ }] ∗ (∀ v, Φ v -∗ Ψ v) -∗ WP e @ s; E [{ Ψ }].
+  Proof. iIntros "[Hwp H]". iApply (ub_twp_wand with "Hwp H"). Qed.
+  Lemma ub_twp_frame_wand s E e Φ R :
+    R -∗ WP e @ s; E [{ v, R -∗ Φ v }] -∗ WP e @ s; E [{ Φ }].
+  Proof.
+    iIntros "HR HWP". iApply (ub_twp_wand with "HWP").
+    iIntros (v) "HΦ". by iApply "HΦ".
+  Qed.
+
+  Lemma ub_twp_wp_step s E e P Φ :
+    TCEq (to_val e) None →
+    ▷ P -∗
+    WP e @ s; E [{ v, P ={E}=∗ Φ v }] -∗ WP e @ s; E {{ Φ }}.
+  Proof.
+    iIntros (?) "HP Hwp".
+    iApply (ub_wp_step_fupd _ _ E _ P with "[HP]"); [auto..|]. by iApply ub_twp_ub_wp.
+  Qed.
+  
+End ub_twp.
+
+
+(** Proofmode class instances *)
+Section proofmode_classes.
+  Context `{!irisGS Λ Σ}.
+  Implicit Types P Q : iProp Σ.
+  Implicit Types Φ : val Λ → iProp Σ.
+  Implicit Types v : val Λ.
+  Implicit Types e : expr Λ.
+
+  Global Instance frame_ub_twp p s E e R Φ Ψ :
+    (∀ v, Frame p R (Φ v) (Ψ v)) →
+    Frame p R (WP e @ s; E [{ Φ }]) (WP e @ s; E [{ Ψ }]) | 2.
+  Proof. rewrite /Frame=> HR. rewrite ub_twp_frame_l. apply ub_twp_mono, HR. Qed.
+
+  Global Instance is_except_0_ub_twp s E e Φ : IsExcept0 (WP e @ s; E [{ Φ }]).
+  Proof. by rewrite /IsExcept0 -{2}fupd_ub_twp -except_0_fupd -fupd_intro. Qed.
+
+  Global Instance elim_modal_bupd_ub_twp p s E e P Φ :
+    ElimModal True p false (|==> P) P (WP e @ s; E [{ Φ }]) (WP e @ s; E [{ Φ }]).
+  Proof.
+    by rewrite /ElimModal intuitionistically_if_elim
+      (bupd_fupd E) fupd_frame_r wand_elim_r fupd_ub_twp.
+  Qed.
+
+  Global Instance elim_modal_fupd_ub_twp p s E e P Φ :
+    ElimModal True p false (|={E}=> P) P (WP e @ s; E [{ Φ }]) (WP e @ s; E [{ Φ }]).
+  Proof.
+    by rewrite /ElimModal intuitionistically_if_elim
+      fupd_frame_r wand_elim_r fupd_ub_twp.
+  Qed.
+
+  Global Instance elim_modal_fupd_ub_twp_atomic p s E1 E2 e P Φ :
+    ElimModal (Atomic StronglyAtomic e) p false
+      (|={E1,E2}=> P) P
+      (WP e @ s; E1 [{ Φ }]) (WP e @ s; E2 [{ v, |={E2,E1}=> Φ v }])%I | 100.
+  Proof.
+    intros ?. by rewrite intuitionistically_if_elim
+                fupd_frame_r wand_elim_r ub_twp_atomic.
+  Qed.
+
+  Global Instance add_modal_fupd_ub_twp s E e P Φ :
+    AddModal (|={E}=> P) P (WP e @ s; E [{ Φ }]).
+  Proof. by rewrite /AddModal fupd_frame_r wand_elim_r fupd_ub_twp. Qed.
+End proofmode_classes.

--- a/theories/ub_logic/ub_weakestpre.v
+++ b/theories/ub_logic/ub_weakestpre.v
@@ -591,6 +591,22 @@ Section exec_ub.
     iSplit; [done|done].
   Qed.
 
+  Lemma exec_ub_strong_ind (Ψ : nonnegreal → expr Λ → state Λ →  iProp Σ) (Z : nonnegreal → cfg Λ → iProp Σ) :
+    (∀ n e σ ε, Proper (dist n) (Ψ ε e σ)) →
+    ⊢ (□ (∀ e σ ε, exec_ub_pre Z (λ '(ε, (e, σ)), Ψ ε e σ ∧ exec_ub e σ Z ε)%I (ε, (e, σ)) -∗ Ψ ε e σ) →
+       ∀ e σ ε, exec_ub e σ Z ε -∗ Ψ ε e σ)%I.
+  Proof.
+    iIntros (HΨ). iIntros "#IH" (e σ ε) "H".
+    set (Ψ' := (λ '(ε, (e, σ)), Ψ ε e σ):
+           (prodO NNRO (prodO (exprO Λ) (stateO Λ))) → iProp Σ).
+    assert (NonExpansive Ψ').
+    { intros n [?[e1 σ1]] [?[e2 σ2]]
+        [?%leibniz_equiv[?%leibniz_equiv ?%leibniz_equiv]].
+      simplify_eq/=. f_equiv. }
+    rewrite /exec_ub/exec_ub'.
+    iApply (least_fixpoint_ind _ Ψ' with "[] H").
+    iModIntro. iIntros ([?[??]]) "H". by iApply "IH".
+  Qed. 
 
 
 (*


### PR DESCRIPTION
This is the branch for including a total wp for the ub logic.

- [x] Add typeclass + notation for twp 
- [x] Implement lemmas for total wp type class
- [x] Define total wp instance for ub logic
- [x] Prove a weak adequacy rule (Terminates up to 1 - ep)
- [x] Prove least upper bound property of reals and hence its corollaries
- [x] Implement a ub_lift for total wp. 
- [x] prove total_ub_lift lemmas
- [x]  Prove stronger adequacy rule (terminate in Phi predicate up to 1 - ep). Assigned to Heili atm
- [x]  Prove basic primitive laws for twp
- [x] Prove planner rule for twp
- [ ] Implement example of rejection sampler
- [ ] Prove termination and probabilities of rejection sampler using adequacy