### PR TITLE
Upgrade to Coq 8.18

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -14,7 +14,7 @@ jobs:
     strategy:
       matrix:
         coq_version:
-          - '8.16.1'
+          - '8.18.0'
         ocaml_version:
           - '4.14.1-flambda'
       max-parallel: 4

--- a/clutch.opam
+++ b/clutch.opam
@@ -14,10 +14,10 @@ bug-reports: "https://github.com/logsem/clutch/issues"
 build: [make "-j%{jobs}%"]
 install: []
 depends: [
-  "coq" { (>= "8.16" & < "8.18~") | (= "dev") }
+  "coq" { (>= "8.18" & < "8.19~") | (= "dev") }
   "coq-coquelicot" { (>= "3.2.0" & <= "3.4.0") }
-  "coq-iris" { (= "4.0.0") | (= "dev") }
-  "coq-stdpp" { (= "1.8.0") | (= "dev") }
+  "coq-iris" { (= "4.1.0") | (= "dev") }
+  "coq-stdpp" { (= "1.9.0") | (= "dev") }
   "coq-autosubst" { (= "1.8") | (= "dev") }
   "coq-mathcomp-ssreflect" { (= "1.17.0") }
   "coq-mathcomp-solvable" { (= "1.17.0") }

--- a/external/proba/basic/Reals_ext.v
+++ b/external/proba/basic/Reals_ext.v
@@ -321,9 +321,10 @@ Proof.
     exfalso. apply is_sup_seq_lub in His.
     destruct His as (Hub&?).
     destruct (Hunbounded (r+1)) as (n&Hle).
-    feed pose proof (Hub (xn n)) as Hle'.
-    { exists n. auto. }
-    rewrite //= in Hle'. nra.
+    pose proof (Hub (xn n)) as Hle'.
+    assert (xn n ≤ r) as Hle''.
+    { apply Hle'. exists n. auto. }
+    rewrite //= in Hle''. nra.
 Qed.
 
 

--- a/external/proba/basic/Series_Ext.v
+++ b/external/proba/basic/Series_Ext.v
@@ -2,7 +2,10 @@
 From discprob.basic Require Import base order bigop_ext.
 Require Import Reals Fourier Psatz.
 From Coquelicot Require Import Rcomplements Rbar Series Lim_seq Hierarchy Markov.
-From mathcomp Require Import ssreflect ssrbool ssrfun eqtype ssrnat seq div choice fintype.
+Set Warnings "-hiding-delimiting-key,-overwriting-delimiting-key".
+From mathcomp Require Import ssrnat.
+Set Warnings "hiding-delimiting-key,overwriting-delimiting-key".
+From mathcomp Require Import ssreflect ssrbool ssrfun eqtype seq div choice fintype.
 Require Import ClassicalEpsilon.
 
 Lemma Rbar_le_fin x y: 0 <= y → Rbar_le x (Finite y) → Rle (real x) y.

--- a/external/proba/basic/Series_Ext.v
+++ b/external/proba/basic/Series_Ext.v
@@ -2,9 +2,7 @@
 From discprob.basic Require Import base order bigop_ext.
 Require Import Reals Fourier Psatz.
 From Coquelicot Require Import Rcomplements Rbar Series Lim_seq Hierarchy Markov.
-Set Warnings "-hiding-delimiting-key,-overwriting-delimiting-key".
-From mathcomp Require Import ssrnat.
-Set Warnings "hiding-delimiting-key,overwriting-delimiting-key".
+#[warning="-hiding-delimiting-key,-overwriting-delimiting-key"] From mathcomp Require Import ssrnat.
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype seq div choice fintype.
 Require Import ClassicalEpsilon.
 

--- a/external/proba/basic/bigop_ext.v
+++ b/external/proba/basic/bigop_ext.v
@@ -436,7 +436,9 @@ Proof.
     [ rewrite Nat.max_l // | rewrite Nat.max_r //].
 Qed.
 
+Set Warnings "-hiding-delimiting-key".
 From mathcomp Require Import ssrnat.
+Set Warnings "hiding-delimiting-key".
 
 Lemma sum_index_ordinal_P_aux {A} (f: A → R) (l: seq A) r P P':
   (∀ i, (i < size l)%nat → P i = P' (nth r l i)) →

--- a/external/proba/basic/bigop_ext.v
+++ b/external/proba/basic/bigop_ext.v
@@ -436,9 +436,7 @@ Proof.
     [ rewrite Nat.max_l // | rewrite Nat.max_r //].
 Qed.
 
-Set Warnings "-hiding-delimiting-key".
-From mathcomp Require Import ssrnat.
-Set Warnings "hiding-delimiting-key".
+#[warning="-hiding-delimiting-key"] From mathcomp Require Import ssrnat.
 
 Lemma sum_index_ordinal_P_aux {A} (f: A → R) (l: seq A) r P P':
   (∀ i, (i < size l)%nat → P i = P' (nth r l i)) →

--- a/external/proba/prob/double.v
+++ b/external/proba/prob/double.v
@@ -10,7 +10,10 @@ From discprob.basic Require Import base order bigop_ext nify Series_Ext.
 From discprob.prob Require Import countable rearrange.
 From stdpp Require tactics.
 Require Import Reals Lia Psatz.
-From mathcomp Require Import ssreflect ssrbool ssrfun eqtype seq bigop fintype ssrnat choice.
+Set Warnings "-hiding-delimiting-key,-overwriting-delimiting-key".
+From mathcomp Require Import ssrnat.
+Set Warnings "hiding-delimiting-key,overwriting-delimiting-key".
+From mathcomp Require Import ssreflect ssrbool ssrfun eqtype seq bigop fintype choice.
 From Coquelicot Require Import Rcomplements Rbar Series Lim_seq Hierarchy Markov.
 
 

--- a/external/proba/prob/double.v
+++ b/external/proba/prob/double.v
@@ -10,9 +10,7 @@ From discprob.basic Require Import base order bigop_ext nify Series_Ext.
 From discprob.prob Require Import countable rearrange.
 From stdpp Require tactics.
 Require Import Reals Lia Psatz.
-Set Warnings "-hiding-delimiting-key,-overwriting-delimiting-key".
-From mathcomp Require Import ssrnat.
-Set Warnings "hiding-delimiting-key,overwriting-delimiting-key".
+#[warning="-hiding-delimiting-key,-overwriting-delimiting-key"] From mathcomp Require Import ssrnat.
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype seq bigop fintype choice.
 From Coquelicot Require Import Rcomplements Rbar Series Lim_seq Hierarchy Markov.
 

--- a/external/proba/prob/rearrange.v
+++ b/external/proba/prob/rearrange.v
@@ -9,7 +9,10 @@
 From discprob.basic Require Import base order bigop_ext nify sval.
 From discprob.prob Require Import countable.
 Require Import Reals Fourier Lia Psatz ClassicalEpsilon.
-From mathcomp Require Import ssreflect ssrbool ssrfun eqtype seq bigop fintype ssrnat choice.
+Set Warnings "-hiding-delimiting-key,-overwriting-delimiting-key".
+From mathcomp Require Import ssrnat.
+Set Warnings "hiding-delimiting-key,overwriting-delimiting-key".
+From mathcomp Require Import ssreflect ssrbool ssrfun eqtype seq bigop fintype choice.
 From Coquelicot Require Import Rcomplements Rbar Series Lim_seq Hierarchy Markov.
 
 Lemma sum_n_m_filter (a: nat → R) (P: pred nat) n m:

--- a/external/proba/prob/rearrange.v
+++ b/external/proba/prob/rearrange.v
@@ -9,9 +9,7 @@
 From discprob.basic Require Import base order bigop_ext nify sval.
 From discprob.prob Require Import countable.
 Require Import Reals Fourier Lia Psatz ClassicalEpsilon.
-Set Warnings "-hiding-delimiting-key,-overwriting-delimiting-key".
-From mathcomp Require Import ssrnat.
-Set Warnings "hiding-delimiting-key,overwriting-delimiting-key".
+#[warning="-hiding-delimiting-key,-overwriting-delimiting-key"] From mathcomp Require Import ssrnat.
 From mathcomp Require Import ssreflect ssrbool ssrfun eqtype seq bigop fintype choice.
 From Coquelicot Require Import Rcomplements Rbar Series Lim_seq Hierarchy Markov.
 

--- a/theories/app_rel_logic/adequacy.v
+++ b/theories/app_rel_logic/adequacy.v
@@ -234,12 +234,12 @@ Section adequacy.
 End adequacy.
 
 Class app_clutchGpreS Σ := App_ClutchGpreS {
-  app_clutchGpreS_iris  :> invGpreS Σ;
-  app_clutchGpreS_heap  :> ghost_mapG Σ loc val;
-  app_clutchGpreS_tapes :> ghost_mapG Σ loc tape;
-  app_clutchGpreS_cfg   :> inG Σ (authUR cfgUR);
-  app_clutchGpreS_prog  :> inG Σ (authR progUR);
-  app_clutchGpreS_err   :> ecGpreS Σ;
+  app_clutchGpreS_iris  :: invGpreS Σ;
+  app_clutchGpreS_heap  :: ghost_mapG Σ loc val;
+  app_clutchGpreS_tapes :: ghost_mapG Σ loc tape;
+  app_clutchGpreS_cfg   :: inG Σ (authUR cfgUR);
+  app_clutchGpreS_prog  :: inG Σ (authR progUR);
+  app_clutchGpreS_err   :: ecGpreS Σ;
 }.
 
 Definition app_clutchΣ : gFunctors :=
@@ -256,6 +256,7 @@ Theorem wp_aRcoupl Σ `{app_clutchGpreS Σ} (e e' : expr) (σ σ' : state) n (ε
   ARcoupl (exec n (e, σ)) (lim_exec (e', σ')) φ ε.
 Proof.
   intros Hwp.
+  eapply pure_soundness.
   eapply (step_fupdN_soundness_no_lc _ n 0).
   iIntros (Hinv) "_".
   iMod (ghost_map_alloc σ.(heap)) as "[%γH [Hh _]]".

--- a/theories/app_rel_logic/app_weakestpre.v
+++ b/theories/app_rel_logic/app_weakestpre.v
@@ -19,7 +19,7 @@ Local Open Scope R.
     and provide predicates describing valid states via [state_interp] and valid
     specification configurations via [spec_interp]. *)
 Class irisGS (Λ : language) (Σ : gFunctors) := IrisG {
-  iris_invGS :> invGS_gen HasNoLc Σ;
+  iris_invGS :: invGS_gen HasNoLc Σ;
   state_interp : state Λ → iProp Σ;
   spec_interp : cfg Λ → iProp Σ;
   err_interp : nonnegreal → iProp Σ;
@@ -573,13 +573,11 @@ Proof.
   apply least_fixpoint_ne_outer; [|done].
   intros ? [[[] []] ?]. rewrite /exec_coupl_pre.
   do 15 f_equiv.
-  (* If this proof breaks with iris > 4.0.0, check the changelog for
-  dist_later. Using f_contractive_fin instead of f_contractive might work. *)
-  { f_equiv. do 2 case_match. f_contractive. do 4 f_equiv.
+  { f_equiv. do 2 case_match. f_contractive_fin. do 4 f_equiv.
     rewrite IH; [done|lia|]. intros ?. eapply dist_S, HΦ. }
-  { case_match. f_contractive. do 4 f_equiv.
+  { case_match. f_contractive_fin. do 4 f_equiv.
     rewrite IH; [done|lia|]. intros ?. eapply dist_S, HΦ. }
-  { do 9 f_equiv. f_contractive. do 4 f_equiv. rewrite IH; [done|lia|].
+  { do 9 f_equiv. f_contractive_fin. do 4 f_equiv. rewrite IH; [done|lia|].
     intros ?. eapply dist_S, HΦ. }
 Qed.
 Global Instance wp_proper s E e :

--- a/theories/app_rel_logic/examples/prfprp.v
+++ b/theories/app_rel_logic/examples/prfprp.v
@@ -619,7 +619,7 @@ Definition test_prp: val :=
      iMod (ec_zero).
      wp_apply (wp_couple_rand_rand_leq val_size val_size val_size val_size _ _ _ nnreal_zero); first done.
      { lra. }
-     { rewrite Rminus_eq_0 /Rdiv Rmult_0_l /=//. }
+     { rewrite Rminus_diag /Rdiv Rmult_0_l /=//. }
 
      iFrame.
      iIntros "!>" (n2 m2 ->) "HK".
@@ -639,7 +639,7 @@ Definition test_prp: val :=
      { pose proof (fin_to_nat_lt m2); lia. }
      { intros; apply lookup_empty. }
      { rewrite fmap_length seq_length.
-       rewrite Rminus_eq_0 /Rdiv Rmult_0_l /=//.
+       rewrite Rminus_diag /Rdiv Rmult_0_l /=//.
      }
 
      iIntros (z) "(HK & Hf & (%l1 & %l2 & %Hperm & Hg))".

--- a/theories/app_rel_logic/primitive_laws.v
+++ b/theories/app_rel_logic/primitive_laws.v
@@ -18,9 +18,9 @@ Class app_clutchGS Σ := HeapG {
   clutchGS_heap_name : gname;
   clutchGS_tapes_name : gname;
   (* CMRA and ghost name for the spec *)
-  clutchGS_spec :> specGS Σ;
+  clutchGS_spec :: specGS Σ;
   (* CMRA and ghost name for the error *)
-  clutchGS_error :> ecGS Σ;
+  clutchGS_error :: ecGS Σ;
 }.
 
 Definition heap_auth `{app_clutchGS Σ} :=

--- a/theories/app_rel_logic/proofmode.v
+++ b/theories/app_rel_logic/proofmode.v
@@ -87,10 +87,10 @@ Tactic Notation "wp_pure" open_constr(efoc) :=
     reshape_expr e ltac:(fun K e' =>
       unify e' efoc;
       eapply (tac_wp_pure _ _ _ K e');
-      [iSolveTC                       (* PureExec *)
+      [tc_solve                       (* PureExec *)
       |try solve_vals_compare_safe    (* The pure condition for PureExec --
          handles trivial goals, including [vals_compare_safe] *)
-      |iSolveTC                       (* IntoLaters *)
+      |tc_solve                       (* IntoLaters *)
       |wp_finish                      (* new goal *)
       ])
     || fail "wp_pure: cannot find" efoc "in" e "or" efoc "is not a redex"
@@ -99,7 +99,7 @@ Tactic Notation "wp_pure" open_constr(efoc) :=
     reshape_expr e ltac:(fun K e' =>
       unify e' efoc;
       (* eapply (tac_twp_pure _ _ _ K e'); *)
-      [iSolveTC                       (* PureExec *)
+      [tc_solve                       (* PureExec *)
       |try solve_vals_compare_safe    (* The pure condition for PureExec *)
       |wp_finish                      (* new goal *)
       ])
@@ -123,10 +123,10 @@ Tactic Notation "wp_pure" open_constr(efoc) "credit:" constr(H) :=
     reshape_expr e ltac:(fun K e' =>
       unify e' efoc;
       (* eapply (tac_wp_pure_credit _ _ _ _ Htmp K e'); *)
-      [iSolveTC                       (* PureExec *)
+      [tc_solve                       (* PureExec *)
       |try solve_vals_compare_safe    (* The pure condition for PureExec --
          handles trivial goals, including [vals_compare_safe] *)
-      |iSolveTC                       (* IntoLaters *)
+      |tc_solve                       (* IntoLaters *)
       |finish ()                      (* new goal *)
       ])
     || fail "wp_pure: cannot find" efoc "in" e "or" efoc "is not a redex"
@@ -215,7 +215,7 @@ Lemma tac_wp_alloc Δ Δ' E j K v Φ :
   envs_entails Δ (WP fill K (Alloc (Val v)) @ E {{ Φ }}).
 Proof.
   rewrite envs_entails_unseal=> ? HΔ.
-  rewrite -wp_bind. eapply wand_apply; first exact: wp_alloc.
+  rewrite -wp_bind. eapply wand_apply; first apply wand_entails, wp_alloc.
   rewrite left_id into_laterN_env_sound; apply later_mono, forall_intro=> l.
   specialize (HΔ l).
   destruct (envs_app _ _ _) as [Δ''|] eqn:HΔ'; [ | contradiction ].
@@ -234,7 +234,7 @@ Lemma tac_wp_load Δ Δ' E i K b l q v Φ :
   envs_entails Δ (WP fill K (Load (LitV l)) @ E {{ Φ }}).
 Proof.
   rewrite envs_entails_unseal=> ?? Hi.
-  rewrite -wp_bind. eapply wand_apply; first exact: wp_load.
+  rewrite -wp_bind. eapply wand_apply; first apply wand_entails, wp_load.
   rewrite into_laterN_env_sound -later_sep envs_lookup_split //; simpl.
   apply later_mono.
   destruct b; simpl.
@@ -253,7 +253,7 @@ Lemma tac_wp_store Δ Δ' E i K l v v' Φ :
 Proof.
   rewrite envs_entails_unseal=> ???.
   destruct (envs_simple_replace _ _ _) as [Δ''|] eqn:HΔ''; [ | contradiction ].
-  rewrite -wp_bind. eapply wand_apply; first by eapply wp_store.
+  rewrite -wp_bind. eapply wand_apply; first by eapply wand_entails, wp_store.
   rewrite into_laterN_env_sound -later_sep envs_simple_replace_sound //; simpl.
   rewrite right_id. by apply later_mono, sep_mono_r, wand_mono.
 Qed.
@@ -333,7 +333,7 @@ Tactic Notation "wp_alloc" ident(l) "as" constr(H) :=
         first
           [reshape_expr e ltac:(fun K e' => eapply (tac_wp_alloc _ _ _ Htmp K))
           |fail 1 "wp_alloc: cannot find 'Alloc' in" e];
-        [iSolveTC
+        [tc_solve
         |finish ()]
     in (process_single ())
   | _ => fail "wp_alloc: not a 'wp'"
@@ -352,7 +352,7 @@ Tactic Notation "wp_load" :=
     first
       [reshape_expr e ltac:(fun K e' => eapply (tac_wp_load _ _ _ _ K))
       |fail 1 "wp_load: cannot find 'Load' in" e];
-    [iSolveTC
+    [tc_solve
     |solve_mapsto ()
     |wp_finish]
   | _ => fail "wp_load: not a 'wp'"
@@ -368,7 +368,7 @@ Tactic Notation "wp_store" :=
     first
       [reshape_expr e ltac:(fun K e' => eapply (tac_wp_store _ _ _ _ K))
       |fail 1 "wp_store: cannot find 'Store' in" e];
-    [iSolveTC
+    [tc_solve
     |solve_mapsto ()
     |pm_reduce; first [wp_seq|wp_finish]]
   | _ => fail "wp_store: not a 'wp'"

--- a/theories/app_rel_logic/spec_ra.v
+++ b/theories/app_rel_logic/spec_ra.v
@@ -20,15 +20,15 @@ Definition cfgUR : ucmra := optionUR (exclR cfgO).
 (** The CMRA for the spec [cfg]. *)
 Class specGS Σ := CfgSG {
   (* the instances we need for [spec_interp] *)
-  specGS_interp_inG :> inG Σ (authUR cfgUR);
+  specGS_interp_inG :: inG Σ (authUR cfgUR);
   specGS_interp_name : gname;
 
   (* the instances we need for [spec_ctx] *)
-  specGS_prog_inG :> inG Σ (authR progUR);
+  specGS_prog_inG :: inG Σ (authR progUR);
   specGS_prog_name : gname;
 
-  specGS_heap :> ghost_mapG Σ loc val;
-  specGS_tapes :> ghost_mapG Σ loc tape;
+  specGS_heap :: ghost_mapG Σ loc val;
+  specGS_tapes :: ghost_mapG Σ loc tape;
   specGS_heap_name : gname;
   specGS_tapes_name : gname;
 }.

--- a/theories/app_rel_logic/spec_rules.v
+++ b/theories/app_rel_logic/spec_rules.v
@@ -21,7 +21,7 @@ Section rules.
     P →
     PureExec P n e e' →
     nclose specN ⊆ E →
-    spec_ctx ∗ ⤇ fill K e ={E}=∗ spec_ctx ∗ ⤇ fill K e'.
+    spec_ctx ∗ ⤇ fill K e ⊢ |={E}=> spec_ctx ∗ ⤇ fill K e'.
   Proof.
     iIntros (HP Hex ?) "[#Hspec Hj]". iFrame "Hspec".
     iInv specN as (ρ e0 σ0 m) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
@@ -38,7 +38,7 @@ Section rules.
   Lemma step_alloc E K e v :
     IntoVal e v →
     nclose specN ⊆ E →
-    spec_ctx ∗ ⤇ fill K (ref e) ={E}=∗ ∃ l, spec_ctx ∗ ⤇ fill K (#l) ∗ l ↦ₛ v.
+    spec_ctx ∗ ⤇ fill K (ref e) ⊢ |={E}=> ∃ l, spec_ctx ∗ ⤇ fill K (#l) ∗ l ↦ₛ v.
   Proof.
     iIntros (<-?) "[#Hinv Hj]". iFrame "Hinv".
     iInv specN as (ρ e σ m) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
@@ -61,7 +61,7 @@ Section rules.
   Lemma step_load E K l q v:
     nclose specN ⊆ E →
     spec_ctx ∗ ⤇ fill K (!#l) ∗ l ↦ₛ{q} v
-    ={E}=∗ spec_ctx ∗ ⤇ fill K (of_val v) ∗ l ↦ₛ{q} v.
+    ⊢ |={E}=> spec_ctx ∗ ⤇ fill K (of_val v) ∗ l ↦ₛ{q} v.
   Proof.
     iIntros (?) "(#Hinv & Hj & Hl)". iFrame "Hinv".
     iInv specN as (ρ e σ m) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
@@ -79,7 +79,7 @@ Section rules.
     IntoVal e v →
     nclose specN ⊆ E →
     spec_ctx ∗ ⤇ fill K (#l <- e) ∗ l ↦ₛ v'
-    ={E}=∗ spec_ctx ∗ ⤇ fill K #() ∗ l ↦ₛ v.
+    ⊢ |={E}=> spec_ctx ∗ ⤇ fill K #() ∗ l ↦ₛ v.
   Proof.
     iIntros (<-?) "(#Hinv & Hj & Hl)". iFrame "Hinv".
     iInv specN as (ρ e σ m) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
@@ -98,7 +98,7 @@ Section rules.
   Lemma step_alloctape E K N z :
     TCEq N (Z.to_nat z) →
     nclose specN ⊆ E →
-    spec_ctx ∗ ⤇ fill K (alloc #z) ={E}=∗ ∃ l, spec_ctx ∗ ⤇ fill K (#lbl: l) ∗ l ↪ₛ (N; []).
+    spec_ctx ∗ ⤇ fill K (alloc #z) ⊢ |={E}=> ∃ l, spec_ctx ∗ ⤇ fill K (#lbl: l) ∗ l ↪ₛ (N; []).
   Proof.
     iIntros (-> ?) "[#Hinv Hj]". iFrame "Hinv".
     iInv specN as (ρ e σ m) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
@@ -121,7 +121,7 @@ Section rules.
     TCEq N (Z.to_nat z) →
     nclose specN ⊆ E →
     spec_ctx ∗ ⤇ fill K (rand(#lbl:l) #z) ∗ l ↪ₛ (N; n :: ns)
-    ={E}=∗ spec_ctx ∗ ⤇ fill K #n ∗ l ↪ₛ (N; ns).
+    ⊢ |={E}=> spec_ctx ∗ ⤇ fill K #n ∗ l ↪ₛ (N; ns).
   Proof.
     iIntros (-> ?) "(#Hinv & Hj & Hl)". iFrame "Hinv".
     iInv specN as (ρ e σ m) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
@@ -314,7 +314,7 @@ Section rules.
   Lemma refines_right_alloctape E K N z :
     TCEq N (Z.to_nat z) →
     nclose specN ⊆ E →
-    refines_right K (alloc #z) ={E}=∗ ∃ l, refines_right K (#lbl: l) ∗ l ↪ₛ (N; []).
+    refines_right K (alloc #z) ⊢ |={E}=> ∃ l, refines_right K (#lbl: l) ∗ l ↪ₛ (N; []).
   Proof.
     iIntros (??) "(?&?)".
     iMod (step_alloctape with "[$]") as (l) "(?&?)"; [done|].
@@ -324,10 +324,10 @@ Section rules.
   Lemma refines_right_rand E K l N z n ns :
     TCEq N (Z.to_nat z) →
     nclose specN ⊆ E →
-    l ↪ₛ (N; n :: ns) -∗
-    refines_right K (rand(#lbl:l) #z ) ={E}=∗ refines_right K #n ∗ l ↪ₛ (N; ns).
+    l ↪ₛ (N; n :: ns) ∗
+    refines_right K (rand(#lbl:l) #z ) ⊢ |={E}=> refines_right K #n ∗ l ↪ₛ (N; ns).
   Proof.
-    iIntros (??) "? (?&?)".
+    iIntros (??) "(?&?&?)".
     iMod (step_rand with "[$]") as "(?&?&?)"; [done|].
     iModIntro; iFrame.
   Qed.

--- a/theories/app_rel_logic/spec_tactics.v
+++ b/theories/app_rel_logic/spec_tactics.v
@@ -104,14 +104,14 @@ Tactic Notation "tp_pure_at" open_constr(ef) :=
     reshape_expr e ltac:(fun K e' =>
       unify e' ef;
       eapply (tac_tp_pure (fill K' e) (K++K') e' j);
-      [by rewrite ?fill_app | iSolveTC | ..])
+      [by rewrite ?fill_app | tc_solve | ..])
   | |- context[environments.Esnoc _ ?H (refines_right ?j ?e)] =>
     reshape_expr e ltac:(fun K e' =>
       unify e' ef;
       eapply (tac_tp_pure e K e' j);
-      [by rewrite ?fill_app | iSolveTC | ..])
+      [by rewrite ?fill_app | tc_solve | ..])
   end;
-  [iSolveTC || fail "tp_pure: cannot eliminate modality in the goal"
+  [tc_solve || fail "tp_pure: cannot eliminate modality in the goal"
   |solve_ndisj || fail "tp_pure: cannot prove 'nclose specN ⊆ ?'"
   (* |iAssumptionCore || fail "tp_pure: cannot find spec_ctx" (* spec_ctx *) *)
   |iAssumptionCore || fail "tp_pure: cannot find the RHS" (* TODO fix error message *)
@@ -181,11 +181,11 @@ Qed.
 Tactic Notation "tp_store" :=
   iStartProof;
   eapply tac_tp_store;
-  [iSolveTC || fail "tp_store: cannot eliminate modality in the goal"
+  [tc_solve || fail "tp_store: cannot eliminate modality in the goal"
   |solve_ndisj || fail "tp_store: cannot prove 'nclose specN ⊆ ?'"
   |iAssumptionCore || fail "tp_store: cannot find the RHS"
   |tp_bind_helper
-  |iSolveTC || fail "tp_store: cannot convert the argument to a value"
+  |tc_solve || fail "tp_store: cannot convert the argument to a value"
   |simpl; reflexivity || fail "tp_store: this should not happen"
   |iAssumptionCore || fail "tp_store: cannot find '? ↦ₛ ?'"
   |pm_reduce (* new goal *)].
@@ -225,7 +225,7 @@ Qed.
 Tactic Notation "tp_load" :=
   iStartProof;
   eapply tac_tp_load;
-  [iSolveTC || fail "tp_load: cannot eliminate modality in the goal"
+  [tc_solve || fail "tp_load: cannot eliminate modality in the goal"
   |solve_ndisj || fail "tp_load: cannot prove 'nclose specN ⊆ ?'"
   |iAssumptionCore || fail "tp_load: cannot find the RHS"
   |tp_bind_helper
@@ -275,11 +275,11 @@ Tactic Notation "tp_alloc" "as" ident(l) constr(H) :=
         | (iIntros H; tp_normalise) || fail 1 "tp_alloc:" H "not correct intro pattern" ] in
   iStartProof;
   eapply tac_tp_alloc;
-  [iSolveTC || fail "tp_alloc: cannot eliminate modality in the goal"
+  [tc_solve || fail "tp_alloc: cannot eliminate modality in the goal"
   |solve_ndisj || fail "tp_alloc: cannot prove 'nclose specN ⊆ ?'"
   |iAssumptionCore || fail "tp_alloc: cannot find the RHS"
   |tp_bind_helper
-  |iSolveTC || fail "tp_alloc: expressions is not a value"
+  |tc_solve || fail "tp_alloc: expressions is not a value"
   |finish ()
 (* new goal *)].
 
@@ -329,8 +329,8 @@ Tactic Notation "tp_alloctape" "as" ident(l) constr(H) :=
         | (iIntros H; tp_normalise) || fail 1 "tp_alloctape:" H "not correct intro pattern" ] in
   iStartProof;
   eapply (tac_tp_alloctape);
-  [iSolveTC || fail "tp_alloctape: cannot eliminate modality in the goal"
-  |iSolveTC || fail "tp_alloctape: cannnot convert bound to a natural number" 
+  [tc_solve || fail "tp_alloctape: cannot eliminate modality in the goal"
+  |tc_solve || fail "tp_alloctape: cannnot convert bound to a natural number"
   |solve_ndisj || fail "tp_alloctape: cannot prove 'nclose specN ⊆ ?'"
   |iAssumptionCore || fail "tp_alloctape: cannot find the RHS"
   |tp_bind_helper
@@ -376,8 +376,8 @@ Qed.
 Tactic Notation "tp_rand" :=
   iStartProof;
   eapply tac_tp_rand;
-  [iSolveTC || fail "tp_rand: cannot eliminate modality in the goal"
-  |iSolveTC || fail "tp_rand: cannot convert bound to a natural number"
+  [tc_solve || fail "tp_rand: cannot eliminate modality in the goal"
+  |tc_solve || fail "tp_rand: cannot convert bound to a natural number"
   |solve_ndisj || fail "tp_rand: cannot prove 'nclose specN ⊆ ?'"
   |iAssumptionCore || fail "tp_rand: cannot find the RHS"
   |tp_bind_helper

--- a/theories/ctx_logic/adequacy.v
+++ b/theories/ctx_logic/adequacy.v
@@ -10,6 +10,7 @@ From clutch.prob_lang Require Import erasure.
 From clutch.common Require Export language.
 From clutch.ctx_logic Require Import weakestpre primitive_laws spec_ra.
 From clutch.prob Require Import distribution.
+Import uPred.
 
 Section adequacy.
   Context `{!clutchGS Σ}.
@@ -191,11 +192,11 @@ Section adequacy.
 End adequacy.
 
 Class clutchGpreS Σ := ClutchGpreS {
-  clutchGpreS_iris  :> invGpreS Σ;
-  clutchGpreS_heap  :> ghost_mapG Σ loc val;
-  clutchGpreS_tapes :> ghost_mapG Σ loc tape;
-  clutchGpreS_cfg   :> inG Σ (authUR cfgUR);
-  clutchGpreS_prog  :> inG Σ (authR progUR);
+  clutchGpreS_iris  :: invGpreS Σ;
+  clutchGpreS_heap  :: ghost_mapG Σ loc val;
+  clutchGpreS_tapes :: ghost_mapG Σ loc tape;
+  clutchGpreS_cfg   :: inG Σ (authUR cfgUR);
+  clutchGpreS_prog  :: inG Σ (authR progUR);
 }.
 
 Definition clutchΣ : gFunctors :=
@@ -212,7 +213,7 @@ Theorem wp_refRcoupl Σ `{clutchGpreS Σ} (e e' : expr) (σ σ' : state) n φ :
   refRcoupl (exec n (e, σ)) (lim_exec (e', σ')) φ.
 Proof.
   intros Hwp.
-  eapply (step_fupdN_soundness_no_lc _ n 0).
+  eapply pure_soundness, (step_fupdN_soundness_no_lc _ n 0).
   iIntros (Hinv) "_".
   iMod (ghost_map_alloc σ.(heap)) as "[%γH [Hh _]]".
   iMod (ghost_map_alloc σ.(tapes)) as "[%γT [Ht _]]".

--- a/theories/ctx_logic/adequacy_rel.v
+++ b/theories/ctx_logic/adequacy_rel.v
@@ -4,8 +4,8 @@ From clutch.ctx_logic Require Import weakestpre model adequacy.
 From clutch.prob_lang Require Import lang.
 
 Class clutchRGpreS Σ := ClutchRGPreS {
-  clutchRGpreS_clutch :> clutchGpreS Σ;
-  prelorelGpreS_na_inv  :> na_invG Σ;
+  clutchRGpreS_clutch :: clutchGpreS Σ;
+  prelorelGpreS_na_inv  :: na_invG Σ;
 }.
 
 Definition clutchRΣ : gFunctors := #[clutchΣ; na_invΣ].

--- a/theories/ctx_logic/model.v
+++ b/theories/ctx_logic/model.v
@@ -9,8 +9,8 @@ From clutch.ctx_logic Require Import weakestpre spec_ra primitive_laws.
 Definition logN : namespace := nroot .@ "logN".
 
 Class clutchRGS Σ := ClutchRGS {
-    clutchRGS_clutchGS :> clutchGS Σ;
-    clutchRGS_na_invG :> na_invG Σ;
+    clutchRGS_clutchGS :: clutchGS Σ;
+    clutchRGS_na_invG :: na_invG Σ;
     clutchRGS_nais : na_inv_pool_name;
 }.
 

--- a/theories/ctx_logic/primitive_laws.v
+++ b/theories/ctx_logic/primitive_laws.v
@@ -18,7 +18,7 @@ Class clutchGS Σ := HeapG {
   clutchGS_heap_name : gname;
   clutchGS_tapes_name : gname;
   (* CMRA and ghost name for the spec *)
-  clutchGS_spec :> specGS Σ;
+  clutchGS_spec :: specGS Σ;
 }.
 
 Definition heap_auth `{clutchGS Σ} :=

--- a/theories/ctx_logic/rel_rules.v
+++ b/theories/ctx_logic/rel_rules.v
@@ -37,8 +37,8 @@ Section rules.
 
   Lemma refines_wp_l E K e1 t A :
     (WP e1 {{ v,
-        REL fill K (of_val v) << t @ E : A }})%I -∗
-    REL fill K e1 << t @ E : A.
+        REL fill K (of_val v) << t @ E : A }})%I
+    ⊢ REL fill K e1 << t @ E : A.
   Proof.
     rewrite refines_eq /refines_def.
     iIntros "He" (K') "Hs Hnais /=".
@@ -53,8 +53,8 @@ Section rules.
     (∀ K', refines_right K' t ={⊤, E'}=∗
              WP e1 @ E' {{ v,
               |={E', ⊤}=> ∃ t', refines_right K' t' ∗
-              REL fill K (of_val v) << t' @ E : A }})%I -∗
-   REL fill K e1 << t @ E : A.
+              REL fill K (of_val v) << t' @ E : A }})%I
+   ⊢ REL fill K e1 << t @ E : A.
   Proof.
     rewrite refines_eq /refines_def.
     iIntros "Hlog" (K') "Hs Hnais /=".
@@ -90,8 +90,8 @@ Section rules.
   (* A helper lemma for proving the stateful reductions for the RHS below *)
   Lemma refines_step_r E K' e1 e2 A :
     (∀ k, refines_right k e2 ={⊤}=∗
-         ∃ v, refines_right k (of_val v) ∗ REL e1 << fill K' (of_val v) @ E : A) -∗
-    REL e1 << fill K' e2 @ E : A.
+         ∃ v, refines_right k (of_val v) ∗ REL e1 << fill K' (of_val v) @ E : A)
+    ⊢ REL e1 << fill K' e2 @ E : A.
   Proof.
     rewrite refines_eq /refines_def /=.
     iIntros "He" (K'') "Hs Hnais /=".
@@ -108,7 +108,7 @@ Section rules.
      freshly generated. If e2' is known, this variant can be used instead *)
   Lemma refines_steps_r E e1 e2 e2' A K' :
     (∀ K, (refines_right K e2 ={⊤}=∗ refines_right K e2'))
-    -∗ (|={⊤}=> REL e1 << ectxi_language.fill K' e2' @ E : A)
+    ⊢ (|={⊤}=> REL e1 << ectxi_language.fill K' e2' @ E : A)
     -∗ REL e1 << ectxi_language.fill K' e2 @ E : A.
   Proof.
     iIntros "upd >Hlog".
@@ -123,7 +123,7 @@ Section rules.
   Lemma refines_alloc_r E K e v t A :
     IntoVal e v →
     (∀ l : loc, l ↦ₛ v -∗ REL t << fill K (of_val #l) @ E : A)%I
-    -∗ REL t << fill K (ref e) @ E : A.
+    ⊢ REL t << fill K (ref e) @ E : A.
   Proof.
     rewrite /IntoVal. intros <-.
     iIntros "Hlog". simpl.
@@ -134,7 +134,7 @@ Section rules.
   Qed.
 
   Lemma refines_load_r E K l q v t A :
-    l ↦ₛ{q} v -∗
+    l ↦ₛ{q} v ⊢
     (l ↦ₛ{q} v -∗ REL t << fill K (of_val v) @ E : A)
     -∗ REL t << (fill K !#l) @ E : A.
   Proof.
@@ -147,9 +147,9 @@ Section rules.
 
   Lemma refines_store_r E K l e e' v v' A :
     IntoVal e' v' →
-    l ↦ₛ v -∗
-    (l ↦ₛ v' -∗ REL e << fill K (of_val #()) @ E : A) -∗
-    REL e << fill K (#l <- e') @ E : A.
+    l ↦ₛ v ⊢
+    (l ↦ₛ v' -∗ REL e << fill K (of_val #()) @ E : A)
+    -∗ REL e << fill K (#l <- e') @ E : A.
   Proof.
     rewrite /IntoVal. iIntros (<-) "Hl Hlog".
     iApply refines_step_r.
@@ -161,7 +161,7 @@ Section rules.
   Lemma refines_alloctape_r E K N z t A :
     TCEq N (Z.to_nat z) →
     (∀ α : loc, α ↪ₛ (N; []) -∗ REL t << fill K (of_val #lbl:α) @ E : A)%I
-    -∗ REL t << fill K (alloc #z) @ E : A.
+    ⊢ REL t << fill K (alloc #z) @ E : A.
   Proof.
     iIntros (->) "Hlog".
     iApply refines_step_r.
@@ -173,7 +173,7 @@ Section rules.
   Lemma refines_randT_r E K α N z n ns t A :
     TCEq N (Z.to_nat z) →
     α ↪ₛ (N; n :: ns)
-    -∗ (α ↪ₛ (N; ns) -∗ REL t << fill K (of_val #n) @ E : A)
+    ⊢ (α ↪ₛ (N; ns) -∗ REL t << fill K (of_val #n) @ E : A)
     -∗ REL t << (fill K (rand(#lbl:α) #z)) @ E : A.
   Proof.
     iIntros (->) "Hα Hlog".
@@ -224,7 +224,7 @@ Section rules.
   (** This rule is useful for proving that functions refine each other *)
   Lemma refines_arrow_val (v v' : val) A A' :
     □(∀ v1 v2, A v1 v2 -∗
-      REL App v (of_val v1) << App v' (of_val v2) : A') -∗
+      REL App v (of_val v1) << App v' (of_val v2) : A') ⊢
     REL (of_val v) << (of_val v') : (A → A')%lrel.
   Proof.
     iIntros "#H".
@@ -242,7 +242,7 @@ Section rules.
     IntoVal e v →
     (▷ (∀ l : loc, l ↦ v -∗
            REL fill K (of_val #l) << t @ E : A))
-    -∗ REL fill K (ref e) << t @ E : A.
+    ⊢ REL fill K (ref e) << t @ E : A.
   Proof.
     iIntros (<-) "Hlog".
     iApply refines_wp_l.
@@ -253,7 +253,7 @@ Section rules.
     (∃ v',
       ▷(l ↦{q} v') ∗
       ▷(l ↦{q} v' -∗ (REL fill K (of_val v') << t @ E : A)))
-    -∗ REL fill K (! #l) << t @ E : A.
+    ⊢ REL fill K (! #l) << t @ E : A.
   Proof.
     iIntros "[%v' [Hl Hlog]]".
     iApply refines_wp_l.
@@ -264,7 +264,7 @@ Section rules.
     IntoVal e v' →
     (∃ v, ▷ l ↦ v ∗
       ▷(l ↦ v' -∗ REL fill K (of_val #()) << t @ E : A))
-    -∗ REL fill K (#l <- e) << t @ E : A.
+    ⊢ REL fill K (#l <- e) << t @ E : A.
   Proof.
     iIntros (<-) "[%v [Hl Hlog]]".
     iApply refines_wp_l.
@@ -274,7 +274,7 @@ Section rules.
   Lemma refines_alloctape_l K E N z t A :
     TCEq N (Z.to_nat z) →
     (▷ (∀ α : loc, α ↪ (N; []) -∗ REL fill K (of_val #lbl:α) << t @ E : A))%I
-    -∗ REL fill K (alloc #z) << t @ E : A.
+    ⊢ REL fill K (alloc #z) << t @ E : A.
   Proof.
     iIntros (->) "Hlog".
     iApply refines_wp_l.
@@ -285,7 +285,7 @@ Section rules.
     TCEq N (Z.to_nat z) →
     (▷ α ↪ (N; n :: ns) ∗
      ▷ (α ↪ (N; ns) -∗ REL fill K (of_val #n) << t @ E : A))
-    -∗ REL fill K (rand(#lbl:α) #z) << t @ E : A.
+    ⊢ REL fill K (rand(#lbl:α) #z) << t @ E : A.
   Proof.
     iIntros (->) "[Hα Hlog]".
     iApply refines_wp_l.
@@ -323,7 +323,7 @@ Section rules.
   Qed.
 
   Lemma refines_wand E e1 e2 A A' :
-    (REL e1 << e2 @ E : A) -∗
+    (REL e1 << e2 @ E : A) ⊢
     (∀ v1 v2, A v1 v2 ={⊤}=∗ A' v1 v2) -∗
     REL e1 << e2 @ E : A'.
   Proof.
@@ -335,7 +335,7 @@ Section rules.
 
   Lemma refines_arrow (v v' : val) A A' :
     □ (∀ v1 v2 : val, □(REL of_val v1 << of_val v2 : A) -∗
-      REL App v (of_val v1) << App v' (of_val v2) : A') -∗
+      REL App v (of_val v1) << App v' (of_val v2) : A') ⊢
     REL (of_val v) << (of_val v') : (A → A')%lrel.
   Proof.
     iIntros "#H".

--- a/theories/ctx_logic/rel_tactics.v
+++ b/theories/ctx_logic/rel_tactics.v
@@ -174,12 +174,12 @@ Tactic Notation "rel_pure_l" open_constr(ef) "in" open_constr(Kf) :=
       unify e' ef;
       eapply (tac_rel_pure_l K e');
       [reflexivity                  (** e = fill K e1 *)
-      |iSolveTC                     (** PureExec ϕ n e1 e2 *)
+      |tc_solve                     (** PureExec ϕ n e1 e2 *)
       | .. ]);
       [try solve_vals_compare_safe                (** φ *)
       |first [left; reflexivity
              | right; reflexivity]                  (** (m = n) ∨ (m = 0) *)
-      |iSolveTC                                     (** IntoLaters *)
+      |tc_solve                                     (** IntoLaters *)
       |simpl; reflexivity           (** eres = fill K e2 *)
       |rel_finish                   (** new goal *)]
   || fail "rel_pure_l: cannot find the reduct".
@@ -194,7 +194,7 @@ Tactic Notation "rel_pure_r" open_constr(ef) "in" open_constr(Kf) :=
       unify e' ef;
       eapply (tac_rel_pure_r K e');
       [reflexivity                  (** e = fill K e1 *)
-      |iSolveTC                     (** PureExec ϕ n e1 e2 *)
+      |tc_solve                     (** PureExec ϕ n e1 e2 *)
       |..]);
       [try solve_vals_compare_safe                (** φ *)
       |solve_ndisj        || fail 1 "rel_pure_r: cannot solve ↑specN ⊆ ?"
@@ -261,7 +261,7 @@ Tactic Notation "rel_load_l" open_constr(ef) "in" open_constr(Kf) :=
        eapply (tac_rel_load_l_simp K); first reflexivity)
     |fail 1 "rel_load_l: cannot find 'Load'"];
   (* the remaining goals are from tac_lel_load_l (except for the first one, which has already been solved by this point) *)
-  [iSolveTC             (** IntoLaters *)
+  [tc_solve             (** IntoLaters *)
   |solve_mapsto ()
   |reflexivity       (** eres = fill K v *)
   |rel_finish  (** new goal *)].
@@ -341,11 +341,11 @@ Tactic Notation "rel_store_l" open_constr(ef) "in" open_constr(Kf) :=
        unify e' ef ;
        eapply (tac_rel_store_l_simpl K);
        [reflexivity (** e = fill K (#l <- e') *)
-       |iSolveTC    (** e' is a value *)
+       |tc_solve    (** e' is a value *)
        |idtac..])
     |fail 1 "rel_store_l: cannot find 'Store'"];
   (* the remaining goals are from tac_rel_store_l (except for the first one, which has already been solved by this point) *)
-  [iSolveTC        (** IntoLaters *)
+  [tc_solve        (** IntoLaters *)
   |solve_mapsto ()
   |reduction.pm_reflexivity || fail "rel_store_l: this should not happen O-:"
   |reflexivity
@@ -363,7 +363,7 @@ Tactic Notation "rel_store_r" open_constr(ef) "in" open_constr(Kf) :=
        unify K Kf ;
        unify e' ef ;
        eapply (tac_rel_store_r K);
-       [reflexivity|iSolveTC|idtac..])
+       [reflexivity|tc_solve|idtac..])
     |fail 1 "rel_store_r: cannot find 'Store'"];
   (* the remaining goals are from tac_rel_store_r (except for the first one, which has already been solved by this point) *)
   [solve_ndisj || fail "rel_store_r: cannot prove 'nclose specN ⊆ ?'"
@@ -398,10 +398,10 @@ Tactic Notation "rel_alloc_l" simple_intropattern(l) "as" constr(H) "at" open_co
        unify e' ef ;
        eapply (tac_rel_alloc_l_simpl K);
        [reflexivity (** e = fill K (Alloc e') *)
-       |iSolveTC    (** e' is a value *)
+       |tc_solve    (** e' is a value *)
        |idtac..])
     |fail 1 "rel_alloc_l: cannot find 'Alloc'"];
-  [iSolveTC        (** IntoLaters *)
+  [tc_solve        (** IntoLaters *)
   |iIntros (l) H; rel_finish  (** new goal *)].
 Tactic Notation "rel_alloc_l" simple_intropattern(l) "as" constr(H) :=
   rel_pures_l ; rel_alloc_l l as H at _ in _.
@@ -424,7 +424,7 @@ Tactic Notation "rel_alloc_r" simple_intropattern(l) "as" constr(H) "at" open_co
        unify e' ef ;
        eapply (tac_rel_alloc_r K);
        [reflexivity  (** t = K'[alloc t'] *)
-       |iSolveTC     (** t' is a value *)
+       |tc_solve     (** t' is a value *)
        |idtac..])
     |fail 1 "rel_alloc_r: cannot find 'Alloc'"];
   [solve_ndisj || fail "rel_alloc_r: cannot prove 'nclose specN ⊆ ?'"
@@ -456,11 +456,11 @@ Tactic Notation "rel_alloctape_l" simple_intropattern(l) "as" constr(H) "at" ope
        unify K Kf ;
        unify e' ef ;
        eapply (tac_rel_alloctape_l_simpl K);
-       [iSolveTC (** TCEq N (Z.to_nat z) → *)
+       [tc_solve (** TCEq N (Z.to_nat z) → *)
        |reflexivity (** e = fill K (Alloc e') *)
        |idtac..])
     |fail 1 "rel_alloctape_l: cannot find 'AllocTape'"];
-  [iSolveTC        (** IntoLaters *)
+  [tc_solve        (** IntoLaters *)
   |iIntros (l) H; rewrite ?Nat2Z.id; rel_finish  (** new goal *)].
 Tactic Notation "rel_alloctape_l" simple_intropattern(l) "as" constr(H) :=
   rel_pures_l ; rel_alloctape_l l as H at _ in _.
@@ -479,7 +479,7 @@ Tactic Notation "rel_alloctape_r" simple_intropattern(l) "as" constr(H) "at" ope
        unify K Kf ;
        unify e' ef ;
        eapply (tac_rel_alloctape_r K);
-       [iSolveTC
+       [tc_solve
        |reflexivity  (** t = K'[alloc t'] *)
        |idtac..])
     |fail 1 "rel_alloctape_r: cannot find 'AllocTape'"];
@@ -540,7 +540,7 @@ Tactic Notation "rel_rand_l" open_constr(ef) "in" open_constr(kf) :=
        eapply (tac_rel_rand_l K); [|reflexivity|..])
     |fail 1 "rel_rand_l: cannot find 'Rand'"];
   (* the remaining goals are from tac_rel_rand_l (except for the first one, which has already been solved by this point) *)
-  [iSolveTC
+  [tc_solve
   |solve_mapsto ()
   |reduction.pm_reflexivity || fail "rel_rand_l: this should not happen O-:"
   |reflexivity
@@ -559,7 +559,7 @@ Tactic Notation "rel_rand_r" open_constr(ef) "in" open_constr(kf) :=
        eapply (tac_rel_rand_r K); [|reflexivity|..])
     |fail 1 "rel_rand_r: cannot find 'Rand'"];
   (* the remaining goals are from tac_rel_rand_r (except for the first one, which has already been solved by this point) *)
-  [iSolveTC
+  [tc_solve
   |solve_ndisj || fail "rel_rand_r: cannot prove 'nclose specN ⊆ ?'"
   |solve_mapsto ()
   |reduction.pm_reflexivity || fail "rel_rand_r: this should not happen O-:"

--- a/theories/ctx_logic/rel_tactics.v
+++ b/theories/ctx_logic/rel_tactics.v
@@ -528,7 +528,6 @@ Proof.
   apply bi.wand_elim_l.
 Qed.
 
-Local Set Warnings "-cast-in-pattern".
 Tactic Notation "rel_rand_l" open_constr(ef) "in" open_constr(kf) :=
   let solve_mapsto _ :=
     let α := match goal with |- _ = Some (_, (?α ↪ _)%I) => α end in

--- a/theories/ctx_logic/spec_ra.v
+++ b/theories/ctx_logic/spec_ra.v
@@ -20,15 +20,15 @@ Definition cfgUR : ucmra := optionUR (exclR cfgO).
 (** The CMRA for the spec [cfg]. *)
 Class specGS Σ := CfgSG {
   (* the instances we need for [spec_interp] *)
-  specGS_interp_inG :> inG Σ (authUR cfgUR);
+  specGS_interp_inG :: inG Σ (authUR cfgUR);
   specGS_interp_name : gname;
 
   (* the instances we need for [spec_ctx] *)
-  specGS_prog_inG :> inG Σ (authR progUR);
+  specGS_prog_inG :: inG Σ (authR progUR);
   specGS_prog_name : gname;
 
-  specGS_heap :> ghost_mapG Σ loc val;
-  specGS_tapes :> ghost_mapG Σ loc tape;
+  specGS_heap :: ghost_mapG Σ loc val;
+  specGS_tapes :: ghost_mapG Σ loc tape;
   specGS_heap_name : gname;
   specGS_tapes_name : gname;
 }.

--- a/theories/ctx_logic/spec_rules.v
+++ b/theories/ctx_logic/spec_rules.v
@@ -20,7 +20,7 @@ Section rules.
     P →
     PureExec P n e e' →
     nclose specN ⊆ E →
-    spec_ctx ∗ ⤇ fill K e ={E}=∗ spec_ctx ∗ ⤇ fill K e'.
+    spec_ctx ∗ ⤇ fill K e ⊢ |={E}=> spec_ctx ∗ ⤇ fill K e'.
   Proof.
     iIntros (HP Hex ?) "[#Hspec Hj]". iFrame "Hspec".
     iInv specN as (ρ e0 σ0 m) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
@@ -37,7 +37,7 @@ Section rules.
   Lemma step_alloc E K e v :
     IntoVal e v →
     nclose specN ⊆ E →
-    spec_ctx ∗ ⤇ fill K (ref e) ={E}=∗ ∃ l, spec_ctx ∗ ⤇ fill K (#l) ∗ l ↦ₛ v.
+    spec_ctx ∗ ⤇ fill K (ref e) ⊢ |={E}=> ∃ l, spec_ctx ∗ ⤇ fill K (#l) ∗ l ↦ₛ v.
   Proof.
     iIntros (<-?) "[#Hinv Hj]". iFrame "Hinv".
     iInv specN as (ρ e σ m) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
@@ -60,7 +60,7 @@ Section rules.
   Lemma step_load E K l q v:
     nclose specN ⊆ E →
     spec_ctx ∗ ⤇ fill K (!#l) ∗ l ↦ₛ{q} v
-    ={E}=∗ spec_ctx ∗ ⤇ fill K (of_val v) ∗ l ↦ₛ{q} v.
+    ⊢ |={E}=> spec_ctx ∗ ⤇ fill K (of_val v) ∗ l ↦ₛ{q} v.
   Proof.
     iIntros (?) "(#Hinv & Hj & Hl)". iFrame "Hinv".
     iInv specN as (ρ e σ m) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
@@ -78,7 +78,7 @@ Section rules.
     IntoVal e v →
     nclose specN ⊆ E →
     spec_ctx ∗ ⤇ fill K (#l <- e) ∗ l ↦ₛ v'
-    ={E}=∗ spec_ctx ∗ ⤇ fill K #() ∗ l ↦ₛ v.
+    ⊢ |={E}=> spec_ctx ∗ ⤇ fill K #() ∗ l ↦ₛ v.
   Proof.
     iIntros (<-?) "(#Hinv & Hj & Hl)". iFrame "Hinv".
     iInv specN as (ρ e σ m) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
@@ -97,7 +97,7 @@ Section rules.
   Lemma step_alloctape E K N z :
     TCEq N (Z.to_nat z) →
     nclose specN ⊆ E →
-    spec_ctx ∗ ⤇ fill K (alloc #z) ={E}=∗ ∃ l, spec_ctx ∗ ⤇ fill K (#lbl: l) ∗ l ↪ₛ (N; []).
+    spec_ctx ∗ ⤇ fill K (alloc #z) ⊢ |={E}=> ∃ l, spec_ctx ∗ ⤇ fill K (#lbl: l) ∗ l ↪ₛ (N; []).
   Proof.
     iIntros (-> ?) "[#Hinv Hj]". iFrame "Hinv".
     iInv specN as (ρ e σ m) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
@@ -120,7 +120,7 @@ Section rules.
     TCEq N (Z.to_nat z) →
     nclose specN ⊆ E →
     spec_ctx ∗ ⤇ fill K (rand(#lbl:l) #z) ∗ l ↪ₛ (N; n :: ns)
-    ={E}=∗ spec_ctx ∗ ⤇ fill K #n ∗ l ↪ₛ (N; ns).
+    ⊢ |={E}=> spec_ctx ∗ ⤇ fill K #n ∗ l ↪ₛ (N; ns).
   Proof.
     iIntros (-> ?) "(#Hinv & Hj & Hl)". iFrame "Hinv".
     iInv specN as (ρ e σ m) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
@@ -271,7 +271,7 @@ Section rules.
   Lemma refines_right_alloctape E K N z :
     TCEq N (Z.to_nat z) →
     nclose specN ⊆ E →
-    refines_right K (alloc #z) ={E}=∗ ∃ l, refines_right K (#lbl: l) ∗ l ↪ₛ (N; []).
+    refines_right K (alloc #z) ⊢ |={E}=> ∃ l, refines_right K (#lbl: l) ∗ l ↪ₛ (N; []).
   Proof.
     iIntros (??) "(?&?)".
     iMod (step_alloctape with "[$]") as (l) "(?&?)"; [done|].
@@ -281,10 +281,10 @@ Section rules.
   Lemma refines_right_rand E K l N z n ns :
     TCEq N (Z.to_nat z) →
     nclose specN ⊆ E →
-    l ↪ₛ (N; n :: ns) -∗
-    refines_right K (rand(#lbl:l) #z) ={E}=∗ refines_right K #n ∗ l ↪ₛ (N; ns).
+    l ↪ₛ (N; n :: ns) ∗
+    refines_right K (rand(#lbl:l) #z) ⊢ |={E}=> refines_right K #n ∗ l ↪ₛ (N; ns).
   Proof.
-    iIntros (??) "? (?&?)".
+    iIntros (??) "(?&?&?)".
     iMod (step_rand with "[$]") as "(?&?&?)"; [done|].
     iModIntro; iFrame.
   Qed.

--- a/theories/ctx_logic/spec_tactics.v
+++ b/theories/ctx_logic/spec_tactics.v
@@ -104,14 +104,14 @@ Tactic Notation "tp_pure_at" open_constr(ef) :=
     reshape_expr e ltac:(fun K e' =>
       unify e' ef;
       eapply (tac_tp_pure (fill K' e) (K++K') e' j);
-      [by rewrite ?fill_app | iSolveTC | ..])
+      [by rewrite ?fill_app | tc_solve | ..])
   | |- context[environments.Esnoc _ ?H (refines_right ?j ?e)] =>
     reshape_expr e ltac:(fun K e' =>
       unify e' ef;
       eapply (tac_tp_pure e K e' j);
-      [by rewrite ?fill_app | iSolveTC | ..])
+      [by rewrite ?fill_app | tc_solve | ..])
   end;
-  [iSolveTC || fail "tp_pure: cannot eliminate modality in the goal"
+  [tc_solve || fail "tp_pure: cannot eliminate modality in the goal"
   |solve_ndisj || fail "tp_pure: cannot prove 'nclose specN ⊆ ?'"
   (* |iAssumptionCore || fail "tp_pure: cannot find spec_ctx" (* spec_ctx *) *)
   |iAssumptionCore || fail "tp_pure: cannot find the RHS" (* TODO fix error message *)
@@ -181,11 +181,11 @@ Qed.
 Tactic Notation "tp_store" :=
   iStartProof;
   eapply tac_tp_store;
-  [iSolveTC || fail "tp_store: cannot eliminate modality in the goal"
+  [tc_solve || fail "tp_store: cannot eliminate modality in the goal"
   |solve_ndisj || fail "tp_store: cannot prove 'nclose specN ⊆ ?'"
   |iAssumptionCore || fail "tp_store: cannot find the RHS"
   |tp_bind_helper
-  |iSolveTC || fail "tp_store: cannot convert the argument to a value"
+  |tc_solve || fail "tp_store: cannot convert the argument to a value"
   |simpl; reflexivity || fail "tp_store: this should not happen"
   |iAssumptionCore || fail "tp_store: cannot find '? ↦ₛ ?'"
   |pm_reduce (* new goal *)].
@@ -225,7 +225,7 @@ Qed.
 Tactic Notation "tp_load" :=
   iStartProof;
   eapply tac_tp_load;
-  [iSolveTC || fail "tp_load: cannot eliminate modality in the goal"
+  [tc_solve || fail "tp_load: cannot eliminate modality in the goal"
   |solve_ndisj || fail "tp_load: cannot prove 'nclose specN ⊆ ?'"
   |iAssumptionCore || fail "tp_load: cannot find the RHS"
   |tp_bind_helper
@@ -275,11 +275,11 @@ Tactic Notation "tp_alloc" "as" ident(l) constr(H) :=
         | (iIntros H; tp_normalise) || fail 1 "tp_alloc:" H "not correct intro pattern" ] in
   iStartProof;
   eapply tac_tp_alloc;
-  [iSolveTC || fail "tp_alloc: cannot eliminate modality in the goal"
+  [tc_solve || fail "tp_alloc: cannot eliminate modality in the goal"
   |solve_ndisj || fail "tp_alloc: cannot prove 'nclose specN ⊆ ?'"
   |iAssumptionCore || fail "tp_alloc: cannot find the RHS"
   |tp_bind_helper
-  |iSolveTC || fail "tp_alloc: expressions is not a value"
+  |tc_solve || fail "tp_alloc: expressions is not a value"
   |finish ()
 (* new goal *)].
 
@@ -329,8 +329,8 @@ Tactic Notation "tp_alloctape" "as" ident(l) constr(H) :=
         | (iIntros H; tp_normalise) || fail 1 "tp_alloctape:" H "not correct intro pattern" ] in
   iStartProof;
   eapply (tac_tp_alloctape);
-  [iSolveTC || fail "tp_alloctape: cannot eliminate modality in the goal"
-  |iSolveTC || fail "tp_alloctape: cannnot convert bound to a natural number" 
+  [tc_solve || fail "tp_alloctape: cannot eliminate modality in the goal"
+  |tc_solve || fail "tp_alloctape: cannnot convert bound to a natural number"
   |solve_ndisj || fail "tp_alloctape: cannot prove 'nclose specN ⊆ ?'"
   |iAssumptionCore || fail "tp_alloctape: cannot find the RHS"
   |tp_bind_helper
@@ -376,8 +376,8 @@ Qed.
 Tactic Notation "tp_rand" :=
   iStartProof;
   eapply tac_tp_rand;
-  [iSolveTC || fail "tp_rand: cannot eliminate modality in the goal"
-  |iSolveTC || fail "tp_rand: cannot convert bound to a natural number"
+  [tc_solve || fail "tp_rand: cannot eliminate modality in the goal"
+  |tc_solve || fail "tp_rand: cannot convert bound to a natural number"
   |solve_ndisj || fail "tp_rand: cannot prove 'nclose specN ⊆ ?'"
   |iAssumptionCore || fail "tp_rand: cannot find the RHS"
   |tp_bind_helper

--- a/theories/ctx_logic/weakestpre.v
+++ b/theories/ctx_logic/weakestpre.v
@@ -19,7 +19,7 @@ Local Open Scope R.
     and provide predicates describing valid states via [state_interp] and valid
     specification configurations via [spec_interp]. *)
 Class irisGS (Λ : language) (Σ : gFunctors) := IrisG {
-  iris_invGS :> invGS_gen HasNoLc Σ;
+  iris_invGS :: invGS_gen HasNoLc Σ;
   state_interp : state Λ → iProp Σ;
   spec_interp : cfg Λ → iProp Σ;
 }.
@@ -496,13 +496,11 @@ Proof.
   apply least_fixpoint_ne_outer; [|done].
   intros ? [[] []]. rewrite /exec_coupl_pre.
   do 10 f_equiv.
-  (* If this proof breaks with iris > 4.0.0, check the changelog for
-  dist_later. Using f_contractive_fin instead of f_contractive might work. *)
-  { f_equiv. do 2 case_match. f_contractive. do 3 f_equiv.
+  { f_equiv. do 2 case_match. f_contractive_fin. do 3 f_equiv.
     rewrite IH; [done|lia|]. intros ?. eapply dist_S, HΦ. }
-  { case_match. f_contractive. do 3 f_equiv.
+  { case_match. f_contractive_fin. do 3 f_equiv.
     rewrite IH; [done|lia|]. intros ?. eapply dist_S, HΦ. }
-  { do 9 f_equiv. f_contractive. do 3 f_equiv. rewrite IH; [done|lia|].
+  { do 9 f_equiv. f_contractive_fin. do 3 f_equiv. rewrite IH; [done|lia|].
     intros ?. eapply dist_S, HΦ. }
 Qed.
 Global Instance wp_proper E e s :

--- a/theories/examples/approximate_samplers/approx_rejection_sampler.v
+++ b/theories/examples/approximate_samplers/approx_rejection_sampler.v
@@ -113,7 +113,7 @@ Section basic.
         * iApply "HΦ"; iModIntro; iPureIntro; eexists _. split; [auto|lia].
         * exfalso.
           rewrite List.Forall_forall in Hsample''.
-          specialize Hsample'' with sample''.
+          specialize Hsample'' with (fin_to_nat sample'').
           apply Hsample''; last reflexivity.
           rewrite in_seq.
           split; first lia.

--- a/theories/examples/approximate_samplers/approx_rejection_sampler_presampled.v
+++ b/theories/examples/approximate_samplers/approx_rejection_sampler_presampled.v
@@ -34,7 +34,7 @@ Section presampled_flip2.
     iAssert (flip2_junk_inv _ _ _ (length (junk ++ block_pad (Z.to_nat 0) 2 junk) `div` 2) _) with "[Hα]" as "Hinv".
     { rewrite /flip2_junk_inv app_assoc.
       iExists _; iFrame; iPureIntro.
-      apply Nat.div_exact; [lia|].
+      apply Nat.Div0.div_exact.
       rewrite app_length.
       apply (blocks_aligned (Z.to_nat 0%nat) 2%nat).
       lia.

--- a/theories/examples/approximate_samplers/approx_walkSAT.v
+++ b/theories/examples/approximate_samplers/approx_walkSAT.v
@@ -548,7 +548,7 @@ Section higherorder_walkSAT.
         * eapply Rlt_le, Rgt_lt, archimed.
       + rewrite -{2}(Rmult_1_r (pos _)) -Rmult_minus_distr_l.
         apply Rgt_not_eq, Rlt_gt, Rmult_lt_0_compat; [apply cond_pos|].
-        apply Rlt_Rminus, lt_1_k.
+        apply Rlt_0_minus, lt_1_k.
     - apply le_IZR.
       apply Rge_le, Rgt_ge.
       eapply Rgt_trans.
@@ -556,7 +556,7 @@ Section higherorder_walkSAT.
       + apply Rlt_gt, Rinv_0_lt_compat.
         rewrite -{2}(Rmult_1_r (pos _)) -Rmult_minus_distr_l.
         apply Rmult_lt_0_compat; [apply cond_pos|].
-        apply Rlt_Rminus, lt_1_k.
+        apply Rlt_0_minus, lt_1_k.
   Qed.
 
 

--- a/theories/examples/awkward_deterministic.v
+++ b/theories/examples/awkward_deterministic.v
@@ -5,7 +5,7 @@ From clutch Require Export clutch.
 Set Default Proof Using "Type*".
 
 Definition oneshotR := csumR (exclR unitR) (agreeR unitR).
-Class oneshotG Σ := { oneshot_inG :> inG Σ oneshotR }.
+Class oneshotG Σ := { oneshot_inG :: inG Σ oneshotR }.
 Definition oneshotΣ : gFunctors := #[GFunctor oneshotR].
 Global Instance subG_oneshotΣ {Σ} : subG oneshotΣ Σ → oneshotG Σ.
 Proof. solve_inG. Qed.
@@ -46,7 +46,7 @@ Section proofs.
   Definition shot γ `{oneshotG Σ} := own γ (Cinr (to_agree ())).
   Lemma new_pending `{oneshotG Σ} : ⊢ |==> ∃ γ, pending γ.
   Proof. by apply own_alloc. Qed.
-  Lemma shoot γ `{oneshotG Σ} : pending γ ==∗ shot γ.
+  Lemma shoot γ `{oneshotG Σ} : pending γ ⊢ |==> shot γ.
   Proof.
     apply own_update.
     intros n [f |]; simpl; eauto.

--- a/theories/examples/crypto/ElGamal.v
+++ b/theories/examples/crypto/ElGamal.v
@@ -5,9 +5,7 @@ From clutch.examples.crypto Require Import valgroup.
 From clutch.examples.crypto Require ElGamal_bijection.
 
 From mathcomp Require ssrnat.
-Set Warnings "-notation-overridden,-ambiguous-paths".
 From mathcomp Require Import zmodp finset ssrbool fingroup.fingroup solvable.cyclic.
-Set Warnings "notation-overridden,ambiguous-paths".
 
 Set Default Proof Using "Type*".
 

--- a/theories/examples/crypto/ElGamal_bijection.v
+++ b/theories/examples/crypto/ElGamal_bijection.v
@@ -1,10 +1,7 @@
 (* We prove that the translation `(λ x, (x + k) mod n) : fin n → fin n` is a
    bijection on `fin n`. This fact is used in the ElGamal security proof. *)
 
-Set Warnings "-notation-overridden,-ambiguous-paths".
 From mathcomp Require Import all_ssreflect ssrnat zmodp fingroup.
-Set Warnings "notation-overridden,ambiguous-paths".
-
 From stdpp Require fin.
 From clutch.prelude Require Import zmodp_fin stdpp_ext.
 

--- a/theories/examples/crypto/valgroup.v
+++ b/theories/examples/crypto/valgroup.v
@@ -23,9 +23,9 @@ Class val_group :=
 
 (* Both of the below seem necessary since there is a subtle difference in the
    domain type DOM, despite the two being convertible. *)
-#[nonuniform] Coercion vgval_as {vg : val_group}
+#[warning="-uniform-inheritance"] Coercion vgval_as {vg : val_group}
   (x : FinGroup.arg_sort (FinGroup.base vgG)) : cval := vgval x.
-#[nonuniform] Coercion vgval_s {vg : val_group}
+#[warning="-uniform-inheritance"] Coercion vgval_s {vg : val_group}
   (x : FinGroup.sort (FinGroup.base vgG)) : cval := vgval x.
 
 Class clutch_group_struct :=
@@ -58,14 +58,14 @@ Class clutch_group `{clutchRGS Σ} {vg : val_group} {cg : clutch_group_struct} :
   Clutch_group
     { int_of_vg_lrel_G : ⊢ (lrel_G → lrel_int)%lrel int_of_vg int_of_vg
     ; vg_of_int_lrel_G : ⊢ (lrel_int → (() + lrel_G))%lrel vg_of_int vg_of_int
-    ; τG_subtype v1 v2 Δ : ⊢ lrel_G v1 v2 -∗ interp τG Δ v1 v2
+    ; τG_subtype v1 v2 Δ : lrel_G v1 v2 ⊢ interp τG Δ v1 v2
     ; is_unit : vunit = 1
     ; is_inv (x : vgG) : ⊢ WP vinv x {{ λ (v : cval), ⌜v = x^-1⌝ }}
     ; is_spec_inv (x : vgG) K :
-      refines_right K (vinv x) ={⊤}=∗ refines_right K (x^-1)
+      refines_right K (vinv x) ⊢ |={⊤}=> refines_right K (x^-1)
     ; is_mult (x y : vgG) : ⊢ WP vmult x y {{ λ (v : cval), ⌜v = (x * y)%g⌝ }}
     ; is_spec_mult (x y : vgG) K :
-      refines_right K (vmult x y) ={⊤}=∗ refines_right K (x * y)%g
+      refines_right K (vmult x y) ⊢ |={⊤}=> refines_right K (x * y)%g
     }.
 
 Definition vexp_typed `{!clutch_group_struct} :
@@ -158,7 +158,7 @@ Proof.
 Qed.
 
 Fact is_spec_exp (b : vgG) (x : nat) K :
-  refines_right K (vexp b #x) ={⊤}=∗ refines_right K (b ^+ x)%g.
+  refines_right K (vexp b #x) ⊢ |={⊤}=> refines_right K (b ^+ x)%g.
 Proof.
   unfold vexp, vexp'. iIntros "hlog".
   tp_pure. tp_pure.

--- a/theories/examples/crypto/valgroup.v
+++ b/theories/examples/crypto/valgroup.v
@@ -4,12 +4,10 @@ From clutch.ctx_logic Require Import weakestpre model spec_ra.
 From clutch.typing Require Import types.
 From clutch Require Import clutch.
 
-Set Warnings "-notation-overridden,-ambiguous-paths".
 From mathcomp Require Import solvable.cyclic choice eqtype finset fintype seq
   ssrbool ssreflect zmodp.
 From mathcomp Require ssralg.
 Import fingroup.
-Set Warnings "notation-overridden,ambiguous-paths".
 Set Bullet Behavior "Strict Subproofs".
 
 Local Open Scope group_scope.

--- a/theories/examples/crypto/valgroup_Zp.v
+++ b/theories/examples/crypto/valgroup_Zp.v
@@ -1,9 +1,9 @@
 From clutch Require Import clutch.
 
-Set Warnings "-notation-overridden,-ambiguous-paths".
-From mathcomp Require Import fingroup solvable.cyclic eqtype
-  fintype ssrbool ssrnat zmodp.
-Set Warnings "notation-overridden,ambiguous-paths".
+Set Warnings "-hiding-delimiting-key,-overwriting-delimiting-key".
+From mathcomp Require Import ssrnat.
+Set Warnings "hiding-delimiting-key,overwriting-delimiting-key".
+From mathcomp Require Import fingroup solvable.cyclic eqtype fintype ssrbool zmodp.
 
 From clutch.prelude Require Import mc_stdlib.
 From clutch.examples.crypto Require Import valgroup.
@@ -83,7 +83,7 @@ Section Z_p.
     by rewrite rem_modn.
   Qed.
 
-  Fact is_spec_inv_p (x : vgG) K : refines_right K (vinv x) ={⊤}=∗ refines_right K x^-1.
+  Fact is_spec_inv_p (x : vgG) K : refines_right K (vinv x) ⊢ |={⊤}=> refines_right K x^-1.
   Proof.
     iIntros => /=. unfold vinv_p, vgval_p. tp_pures => /=.
     rewrite /Zp_trunc -(Nat2Z.inj_sub _ _ (leq_zmodp _ _)) => /=.
@@ -97,13 +97,13 @@ Section Z_p.
   Qed.
 
   Fact is_spec_mult_p (x y : vgG) K :
-    refines_right K (vmult x y) ={⊤}=∗ refines_right K (x * y)%g.
+    refines_right K (vmult x y) ⊢ |={⊤}=> refines_right K (x * y)%g.
   Proof.
     iIntros. rewrite /vmult /cgs_p /vmult_p /= /vgval_p. tp_pures => /=.
     by rewrite -Nat2Z.inj_add -ssrnat.plusE rem_modn.
   Qed.
 
-  Fact τG_subtype_p v1 v2 Δ : ⊢ lrel_G v1 v2 -∗ interp τG Δ v1 v2.
+  Fact τG_subtype_p v1 v2 Δ : lrel_G v1 v2 ⊢ interp τG Δ v1 v2.
   Proof. iIntros ((w&->&->)). iExists _. eauto. Qed.
 
   Definition cg_p : clutch_group (cg := cgs_p).

--- a/theories/examples/crypto/valgroup_Zp.v
+++ b/theories/examples/crypto/valgroup_Zp.v
@@ -1,8 +1,6 @@
 From clutch Require Import clutch.
 
-Set Warnings "-hiding-delimiting-key,-overwriting-delimiting-key".
-From mathcomp Require Import ssrnat.
-Set Warnings "hiding-delimiting-key,overwriting-delimiting-key".
+#[warning="-hiding-delimiting-key,-overwriting-delimiting-key"] From mathcomp Require Import ssrnat.
 From mathcomp Require Import fingroup solvable.cyclic eqtype fintype ssrbool zmodp.
 
 From clutch.prelude Require Import mc_stdlib.

--- a/theories/examples/crypto/valgroup_Zpx.v
+++ b/theories/examples/crypto/valgroup_Zpx.v
@@ -1,10 +1,8 @@
 From clutch Require Import clutch.
 
-From mathcomp Require ssrnat.
-Set Warnings "-notation-overridden,-ambiguous-paths".
+#[warning="-hiding-delimiting-key,-overwriting-delimiting-key"] From mathcomp Require Import ssrnat.
 From mathcomp Require Import fingroup solvable.cyclic choice eqtype finset
   fintype seq ssrbool ssrnat zmodp.
-Set Warnings "notation-overridden,ambiguous-paths".
 
 From clutch.prelude Require Import mc_stdlib.
 From clutch.examples.crypto Require Import valgroup.
@@ -106,7 +104,7 @@ Section Zpx.
   Qed.
 
   Fact is_spec_mult_p (x y : vgG) K :
-    refines_right K (vmult x y) ={⊤}=∗ refines_right K (x * y)%g.
+    refines_right K (vmult x y) ⊢ |={⊤}=> refines_right K (x * y)%g.
   Proof.
     iIntros. rewrite /vmult /cgs_p /vmult_p /= /vgval_p. tp_pures => /=.
     by rewrite -Nat2Z.inj_mul -ssrnat.multE rem_modn.
@@ -133,7 +131,7 @@ Section Zpx.
   Qed.
 
   Fact is_spec_exp' (b : vgG) (x : nat) K :
-    refines_right K (vexp' vunit_p vmult_p b #x) ={⊤}=∗ refines_right K (b ^+ x)%g.
+    refines_right K (vexp' vunit_p vmult_p b #x) ⊢ |={⊤}=> refines_right K (b ^+ x)%g.
   Proof.
     unfold vexp, vexp'. iIntros "hlog".
     tp_pure. tp_pure.
@@ -171,7 +169,7 @@ Section Zpx.
     rewrite rem_modn // /vgval_p. rewrite Zpx_small. rewrite order_inv. done.
   Qed.
 
-  Fact is_spec_inv_p (x : vgG) K : refines_right K x^-1 ={⊤}=∗ refines_right K (x^-1)%g.
+  Fact is_spec_inv_p (x : vgG) K : refines_right K x^-1 ⊢ |={⊤}=> refines_right K (x^-1)%g.
   Proof.
     iIntros "hlog" => /=. rewrite /vinv_p {2}/vgval_p. tp_pures => /=.
     tp_bind (vexp' _ _ _ _)%E.
@@ -180,7 +178,7 @@ Section Zpx.
     rewrite rem_modn //. rewrite Zpx_small order_inv /=. iAssumption.
   Qed.
 
-  Fact τG_subtype_p v1 v2 Δ : ⊢ lrel_G v1 v2 -∗ interp τG Δ v1 v2.
+  Fact τG_subtype_p v1 v2 Δ : lrel_G v1 v2 ⊢ interp τG Δ v1 v2.
   Proof. iIntros ((w&->&->)). iExists _. eauto. Qed.
 
   Definition cg_p : clutch_group (cg := cgs_p).

--- a/theories/examples/keyed_hash.v
+++ b/theories/examples/keyed_hash.v
@@ -58,7 +58,7 @@ Section keyed_hash.
     rewrite ?Nat.shiftr_div_pow2 ?Nat.shiftl_mul_pow2.
     intros Hv.
     specialize (pow2_nonzero MAX_VALS_POW) => ?.
-    rewrite Nat.add_comm Nat.mod_add; last lia.
+    rewrite Nat.add_comm Nat.Div0.mod_add.
     rewrite Nat.mod_small; lia.
   Qed.
 
@@ -89,10 +89,10 @@ Section keyed_hash.
    x `div` k = (x - x `mod` k) `div` k.
   Proof.
     intros Hlt.
-    rewrite Nat.mod_eq; last by lia.
+    rewrite Nat.Div0.mod_eq.
     replace (x - (x - k * x `div` k)) with (k * x `div` k); last first.
     { remember (x `div` k) as y. cut (k * y <= x); try lia.
-      rewrite Heqy. apply Nat.mul_div_le; lia. }
+      rewrite Heqy. apply Nat.Div0.mul_div_le; lia. }
     rewrite Nat.mul_comm Nat.div_mul; lia.
   Qed.
 

--- a/theories/examples/sample_int.v
+++ b/theories/examples/sample_int.v
@@ -545,31 +545,35 @@ Section sample_wide.
       * symmetry; apply Z.compare_lt_iff.
         rewrite ?Z.shiftl_mul_pow2; try lia.
         inversion Hwf1.
-        efeed pose proof (digit_list_to_Z_upper_bound w bs1) as Hub1; eauto.
-        efeed pose proof (digit_list_to_Z_upper_bound w bs2) as Hub2; eauto.
-        unshelve (epose proof (digit_list_to_Z_lower_bound w bs1 _)); eauto.
-        unshelve (epose proof (digit_list_to_Z_lower_bound w bs2 _)); eauto.
+        opose proof (digit_list_to_Z_upper_bound w bs1) as Hub1; eauto.
+        opose proof (digit_list_to_Z_upper_bound w bs2) as Hub2; eauto.
+        unshelve opose proof (digit_list_to_Z_lower_bound w bs1 _); eauto.
+        unshelve opose proof (digit_list_to_Z_lower_bound w bs2 _); eauto.
         subst.
         rewrite -Hlen' in Hub2.
         remember (length bs1 * S w)%Z as k.
         assert (0 ≤ k)%Z by lia.
         eapply (Z.lt_le_trans _ ((b1 + 1) * 2 ^ k + 0)%Z).
-        { ring_simplify. lia. }
+        { ring_simplify.
+          rewrite (@Z.sub_lt_mono_r _ _ (b1 * 2 ^ k)).
+          ring_simplify. auto. }
         { apply Z.add_le_mono; last by lia.
           apply Z.mul_le_mono_nonneg_r; lia. }
       * symmetry; apply Z.compare_gt_iff.
         rewrite ?Z.shiftl_mul_pow2; try lia.
         inversion Hwf1.
-        efeed pose proof (digit_list_to_Z_upper_bound w bs1) as Hub1; eauto.
-        efeed pose proof (digit_list_to_Z_upper_bound w bs2) as Hub2; eauto.
-        unshelve (epose proof (digit_list_to_Z_lower_bound w bs1 _)); eauto.
-        unshelve (epose proof (digit_list_to_Z_lower_bound w bs2 _)); eauto.
+        opose proof (digit_list_to_Z_upper_bound w bs1) as Hub1; eauto.
+        opose proof (digit_list_to_Z_upper_bound w bs2) as Hub2; eauto.
+        opose proof (digit_list_to_Z_lower_bound w bs1 _); eauto.
+        opose proof (digit_list_to_Z_lower_bound w bs2 _); eauto.
         subst.
         rewrite -Hlen' in Hub2.
         remember (length bs1 * S w)%Z as k.
         assert (0 ≤ k)%Z by lia.
         eapply (Z.lt_le_trans _ ((b2 + 1) * 2 ^ k + 0)%Z).
-        { ring_simplify. lia. }
+        { ring_simplify.
+          rewrite (@Z.sub_lt_mono_r _ _ (b2 * 2 ^ k)).
+          ring_simplify. auto. }
         { apply Z.add_le_mono; last by lia.
           apply Z.mul_le_mono_nonneg_r; lia. }
   Qed.

--- a/theories/generic/generic_adequacy.v
+++ b/theories/generic/generic_adequacy.v
@@ -172,9 +172,9 @@ End adequacy.
 
 
 Class clutchGpreS Σ := ClutchGpreS {
-  clutchGpreS_iris  :> invGpreS Σ;
-  clutchGpreS_heap  :> ghost_mapG Σ loc val;
-  clutchGpreS_tapes :> ghost_mapG Σ loc tape;
+  clutchGpreS_iris  :: invGpreS Σ;
+  clutchGpreS_heap  :: ghost_mapG Σ loc val;
+  clutchGpreS_tapes :: ghost_mapG Σ loc tape;
 }.
 
 Definition clutchΣ : gFunctors :=
@@ -190,7 +190,7 @@ Theorem wp_mlift Σ `{clutchGpreS Σ} (M : mlift) (e : expr prob_lang) (σ : sta
   M.(mlift_funct) (exec n (e, σ)) φ.
 Proof.
   intros Hwp.
-  eapply (step_fupdN_soundness_no_lc _ n 0).
+  eapply pure_soundness, (step_fupdN_soundness_no_lc _ n 0).
   iIntros (Hinv) "_".
   iMod (ghost_map_alloc σ.(heap)) as "[%γH [Hh _]]".
   iMod (ghost_map_alloc σ.(tapes)) as "[%γT [Ht _]]".

--- a/theories/generic/generic_weakestpre.v
+++ b/theories/generic/generic_weakestpre.v
@@ -12,7 +12,7 @@ From iris.bi Require Export weakestpre.
 Import uPred.
 
 Class irisGS (Λ : language) (Σ : gFunctors) := IrisG {
-  iris_invGS :> invGS_gen HasNoLc Σ;
+  iris_invGS :: invGS_gen HasNoLc Σ;
   state_interp : state Λ → iProp Σ;
 }.
 Global Opaque iris_invGS.
@@ -383,7 +383,7 @@ Proof.
   apply least_fixpoint_ne_outer; [|done].
   intros ? []. rewrite /exec_mlift_pre.
   do 9 f_equiv.
-  f_contractive.
+  f_contractive_fin.
   do 2 f_equiv. rewrite IH; [done|lia|].
   intros ?. eapply dist_S, HΦ.
 Qed.

--- a/theories/lib/flip.v
+++ b/theories/lib/flip.v
@@ -92,18 +92,18 @@ Section specs.
   (** * Tape allocation  *)
   Lemma refines_allocB_tape_l K E t A :
     (▷ (∀ α : loc, α ↪B [] -∗ REL fill K (of_val #lbl:α) << t @ E : A))%I
-    -∗ REL fill K allocB << t @ E : A.
+    ⊢ REL fill K allocB << t @ E : A.
   Proof. iIntros "?". by iApply refines_alloctape_l. Qed.
 
   Lemma refines_allocB_tape_r E K t A :
     (∀ α : loc, α ↪ₛB [] -∗ REL t << fill K (of_val #lbl:α) @ E : A)%I
-    -∗ REL t << fill K allocB @ E : A.
+    ⊢ REL t << fill K allocB @ E : A.
   Proof. iIntros "?". by iApply refines_alloctape_r. Qed.
 
   (** * Unlabelled flip *)
   Lemma refines_flip_l E K t A :
      ▷ (∀ (b : bool), REL fill K (of_val #b) << t @ E : A)
-    -∗ REL fill K flip << t @ E : A.
+    ⊢ REL fill K flip << t @ E : A.
   Proof.
     iIntros "Hlog".
     iApply refines_wp_l.
@@ -117,7 +117,7 @@ Section specs.
   Lemma refines_flipL_l E K α b bs t A :
     (▷ α ↪B (b :: bs) ∗
      ▷ (α ↪B bs -∗ REL fill K (of_val #b) << t @ E : A))
-    -∗ REL fill K (flipL #lbl:α) << t @ E : A.
+    ⊢ REL fill K (flipL #lbl:α) << t @ E : A.
   Proof.
     iIntros "[Hα Hlog]".
     iApply refines_wp_l.
@@ -126,7 +126,7 @@ Section specs.
 
   Lemma refines_flipL_r E K α b bs t A :
     α ↪ₛB (b :: bs)
-    -∗ (α ↪ₛB bs -∗ REL t << fill K (of_val #b) @ E : A)
+    ⊢ (α ↪ₛB bs -∗ REL t << fill K (of_val #b) @ E : A)
     -∗ REL t << (fill K (flipL #lbl:α)) @ E : A.
   Proof.
     iIntros "Hα Hlog".
@@ -410,7 +410,7 @@ Tactic Notation "rel_allocBtape_l" ident(l) "as" constr(H) :=
        [reflexivity (** e = fill K (Alloc e') *)
        |idtac..])
     |fail 1 "rel_allocBtape_l: cannot find 'allocB'"];
-  [iSolveTC        (** IntoLaters *)
+  [tc_solve        (** IntoLaters *)
   |iIntros (l) H; rel_finish  (** new goal *)].
 
 Lemma tac_rel_allocBtape_r `{!clutchRGS Σ} K' ℶ E e t A :

--- a/theories/prelude/NNRbar.v
+++ b/theories/prelude/NNRbar.v
@@ -386,7 +386,7 @@ Qed.
 
 Lemma NNRbar_not_le_lt (x y : NNRbar) :
   ~ NNRbar_le x y -> NNRbar_lt y x.
-  destruct x ; destruct y ; simpl ; intuition.
+  destruct x ; destruct y ; simpl ; intuition. by apply Rnot_le_lt.
 Qed.
 
 Lemma NNRbar_lt_not_le (x y : NNRbar) :
@@ -550,7 +550,7 @@ Lemma NNRbar_le_antisym (x y : NNRbar) :
   NNRbar_le x y -> NNRbar_le y x -> x = y.
 Proof.
   destruct x ; destruct y ; simpl ; intuition.
-  assert (nonneg n = nonneg n0) as H1; intuition.
+  assert (nonneg n = nonneg n0) as H1. 1: by apply Rle_antisym.
   assert (n = n0) as ->; auto.
   apply nnreal_ext; auto.
 Qed.
@@ -628,7 +628,7 @@ Proof.
   rewrite /nnreal_plus.
   apply nnreal_ext.
   rewrite /nonneg /=.
-  intuition.
+  destruct n. apply Rplus_0_r.
 Qed.
 
 Lemma NNRbar_plus_0_l (x : NNRbar) : NNRbar_plus (Finite nnreal_zero) x = x.
@@ -638,7 +638,7 @@ Proof.
   rewrite /nnreal_plus.
   apply nnreal_ext.
   rewrite /nonneg /=.
-  intuition.
+  destruct n. apply Rplus_0_l.
 Qed.
 
 (*

--- a/theories/prelude/base.v
+++ b/theories/prelude/base.v
@@ -6,11 +6,11 @@
    released more widely we should. *)
 
 Global Set Default Proof Using "Type".
-Export Set Suggest Proof Using. (* also warns about forgotten [Proof.] *)
+#[export] Set Suggest Proof Using. (* also warns about forgotten [Proof.] *)
 
 (* Enforces that every tactic is executed with a single focused goal, meaning
 that bullets and curly braces must be used to structure the proof. *)
-Export Set Default Goal Selector "!".
+#[export] Set Default Goal Selector "!".
 Global Set Bullet Behavior "Strict Subproofs".
 
 From Coq.Unicode Require Export Utf8.

--- a/theories/prelude/iris_ext.v
+++ b/theories/prelude/iris_ext.v
@@ -54,10 +54,11 @@ Section fupd_plainly_derived.
     (P ⊢ Q) → (|={Eo}[Ei]▷=> P) ⊢ (|={Eo}[Ei]▷=> Q).
   Proof. intros HPQ. by apply fupd_mono, later_mono, fupd_mono. Qed.
 
-  Lemma step_fupd_except_0 E1 E2 (P : PROP) : (|={E1}[E2]▷=> ◇ P) ={E1}[E2]▷=∗ P.
+  Lemma step_fupd_except_0 E1 E2 (P : PROP) : (|={E1}[E2]▷=> ◇ P) ⊢ |={E1}[E2]▷=> P.
   Proof. rewrite fupd_except_0 //. Qed.
 
-  Lemma step_fupdN_except_0 E1 E2 (P : PROP) n : (|={E1}[E2]▷=>^(S n) ◇ P) ={E1}[E2]▷=∗^(S n) P.
+  Lemma step_fupdN_except_0 E1 E2 (P : PROP) n :
+    (|={E1}[E2]▷=>^(S n) ◇ P) ⊢ |={E1}[E2]▷=>^(S n) P.
   Proof.
     induction n as [|n IH]; [apply step_fupd_except_0|].
     replace (S (S n)) with (1 + S n)%nat by lia.

--- a/theories/prelude/mc_stdlib.v
+++ b/theories/prelude/mc_stdlib.v
@@ -1,9 +1,10 @@
 From Coq Require Import ZArith.
 From clutch.prelude Require Import base.
 
-Set Warnings "-notation-overridden,-ambiguous-paths".
-From mathcomp Require Import fintype ssrbool ssrnat zmodp.
-Set Warnings "notation-overridden,ambiguous-paths".
+Set Warnings "-hiding-delimiting-key,-overwriting-delimiting-key".
+From mathcomp Require Import ssrnat.
+Set Warnings "hiding-delimiting-key,overwriting-delimiting-key".
+From mathcomp Require Import fintype ssrbool zmodp.
 
 Fact rem_modn (x p : nat) (_ : p <> 0) :
   (Z.rem (Z.of_nat x) (Z.of_nat p))%Z = Z.of_nat (div.modn x p).

--- a/theories/prelude/mc_stdlib.v
+++ b/theories/prelude/mc_stdlib.v
@@ -1,9 +1,7 @@
 From Coq Require Import ZArith.
 From clutch.prelude Require Import base.
 
-Set Warnings "-hiding-delimiting-key,-overwriting-delimiting-key".
-From mathcomp Require Import ssrnat.
-Set Warnings "hiding-delimiting-key,overwriting-delimiting-key".
+#[warning="-hiding-delimiting-key,-overwriting-delimiting-key"] From mathcomp Require Import ssrnat.
 From mathcomp Require Import fintype ssrbool zmodp.
 
 Fact rem_modn (x p : nat) (_ : p <> 0) :

--- a/theories/prelude/stdpp_ext.v
+++ b/theories/prelude/stdpp_ext.v
@@ -29,8 +29,8 @@ Section base.
   Qed.
 
   Class Bij {A B} (f : A → B) := {
-    bij_inj :> Inj (=) (=) f;
-    bij_surj :> Surj (=) f;
+    bij_inj :: Inj (=) (=) f;
+    bij_surj :: Surj (=) f;
   }.
 
   Global Existing Instance bij_inj.
@@ -306,7 +306,9 @@ Section finite.
   Lemma encode_inv_nat_finite n :
     encode_inv_nat n = enum A !! n.
   Proof.
-    unfold encode_inv_nat. simpl.
+    unfold encode_inv_nat.
+    (* TODO this assert used to be computed by simpl before 8.18. *)
+    assert ((decode_nat n) = (enum A !! pred (Pos.to_nat (Pos.of_nat (S n))))) as -> by reflexivity.
     rewrite Nat2Pos.id; [|done].
     destruct (decide (n < card A)%nat) as [Hlt | Hnlt%not_lt]; simpl.
     - destruct (encode_inv_decode n Hlt) as (? & Hdec & Henc).

--- a/theories/prob/countable_sum.v
+++ b/theories/prob/countable_sum.v
@@ -338,6 +338,7 @@ Section series_nat.
     destruct n eqn:Hn; simpl; auto.
     rewrite decide_False //=; [ | lia].
     rewrite Nat2Pos.inj_succ //
+              positive_N_nat
               Pos.pred_succ
               Nat2Pos.id //
               option_guard_True //

--- a/theories/prob/countable_sum_compat.v
+++ b/theories/prob/countable_sum_compat.v
@@ -16,10 +16,9 @@ Proof.
   intros x.
   specialize (pos_INR_nat_of_P (countable.encode x)).
   destruct HC => //=.
-  rewrite /countable.decode/countable.encode/encode_nat.
-  rewrite Nat.succ_pred.
-  { rewrite Pos2Nat.id decode_encode //=. }
-  { lia. }
+  rewrite /countable.decode/countable.encode.
+  rewrite decode_encode_nat.
+  intros. reflexivity.
 Defined.
 
 Definition StdppCountEqMixin {T : Type} `{EqDecision T}:

--- a/theories/tpref_logic/adequacy.v
+++ b/theories/tpref_logic/adequacy.v
@@ -188,7 +188,10 @@ Section refines.
   Proof.
     rewrite refines_soundness_laterN.
     rewrite bi.except_0_into_later.
-    eapply (uPred.soundness _ (S (S n))).
+    intros ?.
+    eapply uPred.pure_soundness.
+    eapply (uPred.laterN_soundness _ (S (S n))).
+    done.
   Qed.
 
 End refines.

--- a/theories/tpref_logic/examples/coin_random_walk.v
+++ b/theories/tpref_logic/examples/coin_random_walk.v
@@ -23,7 +23,7 @@ Lemma exec_random_walk n :
   SeriesC (exec n true) = 1 - (1/2)^n.
 Proof.
   induction n.
-  { rewrite Rminus_eq_0 /= dzero_mass //. }
+  { rewrite Rminus_diag /= dzero_mass //. }
   rewrite exec_Sn_not_final; [|by eapply to_final_None].
   rewrite /markov.step /=.
   rewrite fair_coin_dbind_mass.
@@ -40,7 +40,7 @@ Proof.
   - simpl. setoid_rewrite exec_random_walk.
     intros ϵ. split.
     + intros n. trans 1.
-      * apply Rminus_gt_0_lt.
+      * apply Rlt_0_minus.
         assert (1 - (1 - (1 / 2) ^ n) = (1 / 2) ^ n) as -> by lra.
         apply pow_lt. lra.
       * rewrite -{1}(Rplus_0_r 1).

--- a/theories/tpref_logic/examples/determinize.v
+++ b/theories/tpref_logic/examples/determinize.v
@@ -156,8 +156,8 @@ Section determinize_flip_spec.
     wp_pures.
     wp_apply (rwp_couple_flip with "Hspec").
     { eapply flip_couple. }
-    iIntros (? [b |]) "[Hspec %]"; [|done]; subst.
-    destruct b; wp_pures.
+    iIntros (? [bb |]) "[Hspec %]"; [|done]; subst.
+    destruct bb; wp_pures.
     - iModIntro. iApply "HΨ2". iFrame. eauto.
     - iModIntro. iApply "HΨ2". iFrame. iRight.
       iExists _. iSplit; [done|]. iPureIntro.

--- a/theories/tpref_logic/seq_weakestpre.v
+++ b/theories/tpref_logic/seq_weakestpre.v
@@ -3,7 +3,7 @@ From iris.base_logic.lib Require Export na_invariants.
 From clutch.tpref_logic Require Export weakestpre spec.
 
 Class seqG (Σ: gFunctors) := {
-  seqG_na_invG :> na_invG Σ;
+  seqG_na_invG :: na_invG Σ;
   seqG_name: gname;
 }.
 

--- a/theories/tpref_logic/spec.v
+++ b/theories/tpref_logic/spec.v
@@ -68,14 +68,14 @@ Definition specUR (δ : markov) : ucmra := optionUR (exclR (leibnizO (mstate δ)
 Definition authUR_spec (δ : markov) : ucmra := authUR (specUR δ).
 
 Class specPreG (δ : markov) (Σ : gFunctors) := SpecPreG {
-  specG_pre_authUR :> inG Σ (authUR_spec δ);
+  specG_pre_authUR :: inG Σ (authUR_spec δ);
 }.
 Definition specΣ (δ : markov) : gFunctors := GFunctor (authUR_spec δ).
 Global Instance subG_tprGPreS {δ Σ} : subG (specΣ δ) Σ → specPreG δ Σ.
 Proof. solve_inG. Qed.
 
 Class specG (δ : markov) (Σ : gFunctors) := SpecG {
-  specG_authUR :> inG Σ (authUR_spec δ);
+  specG_authUR :: inG Σ (authUR_spec δ);
   specG_gname : gname;
 }.
 

--- a/theories/tpref_logic/weakestpre.v
+++ b/theories/tpref_logic/weakestpre.v
@@ -15,7 +15,7 @@ Import uPred.
 Local Open Scope R.
 
 Class tprwpG (Λ : language) (Σ : gFunctors) := IrisG {
-  iris_invGS :> invGS_gen HasNoLc Σ;
+  iris_invGS :: invGS_gen HasNoLc Σ;
   state_interp : state Λ → iProp Σ;
 }.
 Global Opaque iris_invGS.
@@ -824,7 +824,7 @@ Proof.
     rewrite -(dret_id_right (dret _)).
     eapply refRcoupl_dbind; [|done].
     intros ? [] ? =>/=. apply refRcoupl_dret. eauto. }
-  iIntros (?? (e2 & -> &?)).
+  iIntros (?? (? & -> &?)).
   iMod ("H" with "[//]") as "($ & $ & H)".
   iModIntro.
   by iApply rwp_bind.

--- a/theories/typing/interp.v
+++ b/theories/typing/interp.v
@@ -48,7 +48,7 @@ Section semtypes.
 
   Lemma unboxed_type_sound τ Δ v v' :
     UnboxedType τ →
-    interp τ Δ v v' -∗ ⌜val_is_unboxed v ∧ val_is_unboxed v'⌝.
+    interp τ Δ v v' ⊢ ⌜val_is_unboxed v ∧ val_is_unboxed v'⌝.
   Proof.
     induction 1; simpl;
     first [iDestruct 1 as (? ?) "[% [% ?]]"
@@ -59,7 +59,7 @@ Section semtypes.
 
   Lemma eq_type_sound τ Δ v v' :
     EqType τ →
-    interp τ Δ v v' -∗ ⌜v = v'⌝.
+    interp τ Δ v v' ⊢ ⌜v = v'⌝.
   Proof.
     intros Hτ; revert v v'; induction Hτ; iIntros (v v') "#H1 /=".
     - by iDestruct "H1" as %[-> ->].
@@ -78,7 +78,7 @@ Section semtypes.
 
   Lemma unboxed_type_eq τ Δ v1 v2 w1 w2 :
     UnboxedType τ →
-    interp τ Δ v1 v2 -∗
+    interp τ Δ v1 v2 ⊢
     interp τ Δ w1 w2 -∗
     |={⊤}=> ⌜v1 = w1 ↔ v2 = w2⌝.
   Proof.
@@ -238,14 +238,14 @@ Section env_typed.
 
   Lemma env_ltyped2_lookup Γ vs x A :
     Γ !! x = Some A →
-    ⟦ Γ ⟧* vs -∗ ∃ v1 v2, ⌜ vs !! x = Some (v1,v2) ⌝ ∧ A v1 v2.
+    ⟦ Γ ⟧* vs ⊢ ∃ v1 v2, ⌜ vs !! x = Some (v1,v2) ⌝ ∧ A v1 v2.
   Proof.
     intros ?. rewrite /env_ltyped2 big_sepM2_lookup_l //.
     iDestruct 1 as ([v1 v2] ?) "H". eauto with iFrame.
   Qed.
 
   Lemma env_ltyped2_insert Γ vs x A v1 v2 :
-    A v1 v2 -∗ ⟦ Γ ⟧* vs -∗
+    A v1 v2 ⊢ ⟦ Γ ⟧* vs -∗
     ⟦ (binder_insert x A Γ) ⟧* (binder_insert x (v1,v2) vs).
   Proof.
     destruct x as [|x]=> /=; first by auto.
@@ -258,7 +258,7 @@ Section env_typed.
   Proof. apply (big_sepM2_empty' _). Qed.
 
   Lemma env_ltyped2_empty_inv vs :
-    ⟦ ∅ ⟧* vs -∗ ⌜vs = ∅⌝.
+    ⟦ ∅ ⟧* vs ⊢ ⌜vs = ∅⌝.
   Proof. apply big_sepM2_empty_r. Qed.
 
   Global Instance env_ltyped2_persistent Γ vs : Persistent (⟦ Γ ⟧* vs).

--- a/theories/ub_logic/adequacy.v
+++ b/theories/ub_logic/adequacy.v
@@ -238,10 +238,10 @@ End adequacy.
 
 
 Class ub_clutchGpreS Σ := UB_ClutchGpreS {
-  ub_clutchGpreS_iris  :> invGpreS Σ;
-  ub_clutchGpreS_heap  :> ghost_mapG Σ loc val;
-  ub_clutchGpreS_tapes :> ghost_mapG Σ loc tape;
-  ub_clutchGpreS_err   :> ecGpreS Σ;
+  ub_clutchGpreS_iris  :: invGpreS Σ;
+  ub_clutchGpreS_heap  :: ghost_mapG Σ loc val;
+  ub_clutchGpreS_tapes :: ghost_mapG Σ loc tape;
+  ub_clutchGpreS_err   :: ecGpreS Σ;
 }.
 
 Definition ub_clutchΣ : gFunctors :=
@@ -256,7 +256,7 @@ Theorem wp_union_bound Σ `{ub_clutchGpreS Σ} (e : expr) (σ : state) n (ε : n
   ub_lift (exec n (e, σ)) φ ε.
 Proof.
   intros Hwp.
-  eapply (step_fupdN_soundness_no_lc _ n 0).
+  eapply pure_soundness, (step_fupdN_soundness_no_lc _ n 0).
   iIntros (Hinv) "_".
   iMod (ghost_map_alloc σ.(heap)) as "[%γH [Hh _]]".
   iMod (ghost_map_alloc σ.(tapes)) as "[%γT [Ht _]]".

--- a/theories/ub_logic/cf_hash.v
+++ b/theories/ub_logic/cf_hash.v
@@ -77,7 +77,7 @@ Section coll_free_hash.
   Lemma coll_free_insert (m : gmap nat Z) (n : nat) (z : Z) :
     m !! n = None ->
     coll_free m ->
-    Forall (λ x, z ≠ snd x) (gmap_to_list m) ->
+    Forall (λ x, z ≠ snd x) (map_to_list m) ->
     coll_free (<[ n := z ]>m).
   Proof.
     intros Hnone Hcoll HForall.
@@ -138,7 +138,7 @@ Section coll_free_hash.
       ⌜ f = compute_cf_hash_specialized #hm #vs #s #r⌝ ∗
       map_list hm ((λ b, LitV (LitInt b)) <$> m) ∗
       ⌜ sval < rval ⌝ ∗
-      ⌜ sval = (length (gmap_to_list m)) ⌝ ∗
+      ⌜ sval = (length (map_to_list m)) ⌝ ∗
       (* The current reserve plus the amortized cost times the number of insertions
          until the next resize is enough to pay for all the error *)
       ⌜(ε + (rval - sval)*( 3 * init_r)/(4 * init_val_size) >=
@@ -498,7 +498,7 @@ Section coll_free_hash.
     rewrite lookup_fmap Hlookup /=. wp_pures.
     wp_load. wp_pures.
     wp_bind (rand _)%E.
-    wp_apply (wp_rand_err_list_int _ (vsval - 1) (map (λ p, snd p) (gmap_to_list m))); auto.
+    wp_apply (wp_rand_err_list_int _ (vsval - 1) (map (λ p, snd p) (map_to_list m))); auto.
     rewrite map_length -Hlen.
     iPoseProof (cf_update_potential _ _ _ _ _ _
                  with "[Herr2 //] [Htot_err //] [Herr //]")
@@ -597,7 +597,7 @@ Section coll_free_hash.
     rewrite lookup_fmap Hlookup. wp_pures.
     wp_load. wp_pures.
     wp_bind (rand _)%E.
-    wp_apply (wp_rand_err_list_int _ (vsval - 1) (map (λ p, snd p) (gmap_to_list m))); auto.
+    wp_apply (wp_rand_err_list_int _ (vsval - 1) (map (λ p, snd p) (map_to_list m))); auto.
     rewrite map_length -Hlen.
     iPoseProof (cf_update_potential_resize vsval sval rval _ _ Hvspos
                  with "[Herr2 //] [//] [] [Herr //]")

--- a/theories/ub_logic/dynamic_vec.v
+++ b/theories/ub_logic/dynamic_vec.v
@@ -252,7 +252,7 @@ Section faulty_allocator.
       rewrite cons_middle app_assoc insert_app_l.
       - rewrite -(Nat.add_0_r sval) Hlen1 /=.
         rewrite insert_app_r /=.
-        rewrite -app_nil_end. iFrame.
+        rewrite app_nil_r. iFrame.
       - rewrite app_length /=.
         lia.
     }

--- a/theories/ub_logic/error_credits.v
+++ b/theories/ub_logic/error_credits.v
@@ -147,7 +147,7 @@ End NNR.
 
 (** The ghost state for error credits *)
 Class ecGpreS (Σ : gFunctors) := EcGpreS {
-  ecGpreS_inG :> inG Σ (authR realUR)
+  ecGpreS_inG :: inG Σ (authR realUR)
 }.
 
 Class ecGS (Σ : gFunctors) := EcGS {
@@ -301,6 +301,12 @@ Section error_credit_theory.
     IntoSep (€ (nnreal_plus ε1 ε2)) (€ ε1) (€ ε2) | 0.
   Proof.
     by rewrite /IntoSep ec_split.
+  Qed.
+
+  Global Instance combine_sep_as_ec_add ε1 ε2 :
+    CombineSepAs (€ ε1) (€ ε2) (€ (nnreal_plus ε1 ε2)) | 0.
+  Proof.
+    by rewrite /CombineSepAs ec_split.
   Qed.
 
 End error_credit_theory.

--- a/theories/ub_logic/hash.v
+++ b/theories/ub_logic/hash.v
@@ -111,7 +111,7 @@ Section simple_bit_hash.
   Lemma coll_free_insert (m : gmap nat Z) (n : nat) (z : Z) :
     m !! n = None ->
     coll_free m ->
-    Forall (λ x, z ≠ snd x) (gmap_to_list m) ->
+    Forall (λ x, z ≠ snd x) (map_to_list m) ->
     coll_free (<[ n := z ]>m).
   Proof.
     intros Hnone Hcoll HForall.
@@ -186,7 +186,7 @@ Section simple_bit_hash.
 
   Lemma wp_insert_no_coll E f m (n : nat) :
     m !! n = None →
-    {{{ coll_free_hashfun f m ∗ € (nnreal_div (nnreal_nat (length (gmap_to_list m))) (nnreal_nat(val_size+1))) 
+    {{{ coll_free_hashfun f m ∗ € (nnreal_div (nnreal_nat (length (map_to_list m))) (nnreal_nat(val_size+1)))
     }}}
       f #n @ E
     {{{ (v : Z), RET #v; coll_free_hashfun f (<[ n := v ]>m) }}}.
@@ -199,7 +199,7 @@ Section simple_bit_hash.
     iIntros (vret) "(Hhash&->)".
     rewrite lookup_fmap Hlookup /=. wp_pures.
     wp_bind (rand _)%E.
-    wp_apply (wp_rand_err_list_int _ val_size (map (λ p, snd p) (gmap_to_list m))); auto.
+    wp_apply (wp_rand_err_list_int _ val_size (map (λ p, snd p) (map_to_list m))); auto.
     rewrite map_length.
     iFrame.
     iIntros "%x %HForall".
@@ -377,7 +377,6 @@ Section amortized_hash.
       by apply le_INR.
   Qed.
   
-
   Lemma wp_insert_new_amortized E f m (n : nat) :
     m !! n = None →
     (size m < max_hash_size)%nat ->
@@ -435,7 +434,7 @@ Section amortized_hash.
         rewrite -Rmult_plus_distr_l.
         f_equal.
     - wp_apply (wp_insert_no_coll with "[H Hε]"); [done|..].
-      + iFrame. done. 
+      + rewrite map_to_list_length. iFrame. done.
       + iIntros (v) "[H %]".
         iApply "HΦ".
         iSplitL; last done.

--- a/theories/ub_logic/primitive_laws.v
+++ b/theories/ub_logic/primitive_laws.v
@@ -17,7 +17,7 @@ Class ub_clutchGS Σ := HeapG {
   clutchGS_heap_name : gname;
   clutchGS_tapes_name : gname;
   (* CMRA and ghost name for the error *)
-  ub_clutchGS_error :> ecGS Σ;
+  ub_clutchGS_error :: ecGS Σ;
 }.
 
 

--- a/theories/ub_logic/proofmode.v
+++ b/theories/ub_logic/proofmode.v
@@ -197,10 +197,10 @@ Tactic Notation "wp_pure" open_constr(efoc) :=
     reshape_expr e ltac:(fun K e' =>
       unify e' efoc;
       eapply (tac_wp_pure _ _ _ K e');
-      [iSolveTC                       (* PureExec *)
+      [tc_solve                       (* PureExec *)
       |try solve_vals_compare_safe    (* The pure condition for PureExec --
          handles trivial goals, including [vals_compare_safe] *)
-      |iSolveTC                       (* IntoLaters *)
+      |tc_solve                       (* IntoLaters *)
       |wp_finish                      (* new goal *)
       ])
     || fail "wp_pure: cannot find" efoc "in" e "or" efoc "is not a redex"
@@ -209,7 +209,7 @@ Tactic Notation "wp_pure" open_constr(efoc) :=
     reshape_expr e ltac:(fun K e' =>
       unify e' efoc;
        eapply (tac_twp_pure _ _ K e'); 
-      [iSolveTC                       (* PureExec *)
+      [tc_solve                       (* PureExec *)
       |try solve_vals_compare_safe    (* The pure condition for PureExec *)
       |wp_finish                      (* new goal *)
       ])
@@ -233,10 +233,10 @@ Tactic Notation "wp_pure" open_constr(efoc) "credit:" constr(H) :=
     reshape_expr e ltac:(fun K e' =>
       unify e' efoc;
       (* eapply (tac_wp_pure_credit _ _ _ _ Htmp K e'); *)
-      [iSolveTC                       (* PureExec *)
+      [tc_solve                       (* PureExec *)
       |try solve_vals_compare_safe    (* The pure condition for PureExec --
          handles trivial goals, including [vals_compare_safe] *)
-      |iSolveTC                       (* IntoLaters *)
+      |tc_solve                       (* IntoLaters *)
       |finish ()                      (* new goal *)
       ])
     || fail "wp_pure: cannot find" efoc "in" e "or" efoc "is not a redex"
@@ -513,7 +513,7 @@ Tactic Notation "wp_alloc" ident(l) "as" constr(H) :=
         first
           [reshape_expr e ltac:(fun K e' => eapply (tac_wp_alloc _ _ _ Htmp K))
           |fail 1 "wp_alloc: cannot find 'Alloc' in" e];
-        [iSolveTC
+        [tc_solve
         |finish ()]
     in (process_single ())
   | |- envs_entails _ (twp ?s ?E ?e ?Q) =>
@@ -539,7 +539,7 @@ Tactic Notation "wp_load" :=
     first
       [reshape_expr e ltac:(fun K e' => eapply (tac_wp_load _ _ _ _ K))
       |fail 1 "wp_load: cannot find 'Load' in" e];
-    [iSolveTC
+    [tc_solve
     |solve_mapsto ()
     |wp_finish]
   | |- envs_entails _ (twp ?s ?E ?e ?Q) =>
@@ -561,7 +561,7 @@ Tactic Notation "wp_store" :=
     first
       [reshape_expr e ltac:(fun K e' => eapply (tac_wp_store _ _ _ _ K))
       |fail 1 "wp_store: cannot find 'Store' in" e];
-    [iSolveTC
+    [tc_solve
     |solve_mapsto ()
     |pm_reduce; first [wp_seq|wp_finish]]
   | |- envs_entails _ (twp ?s ?E ?e ?Q) =>

--- a/theories/ub_logic/seq_amplification.v
+++ b/theories/ub_logic/seq_amplification.v
@@ -137,7 +137,7 @@ Section seq_ampl.
     rewrite fR_closed_2.
     apply Rcomplements.Rle_minus_l.
     rewrite -{1}(Rplus_0_r 1%R); apply Rplus_le_compat_l.
-    apply Rcomplements.Rdiv_le_0_compat; [apply -> Rcomplements.Rminus_le_0 | apply Rlt_Rminus ].
+    apply Rcomplements.Rdiv_le_0_compat; [apply -> Rcomplements.Rminus_le_0 | apply Rlt_0_minus ].
     - apply pow_R1_Rle.
       pose (pos_INR N1).
       rewrite S_INR.

--- a/theories/ub_logic/total_adequacy.v
+++ b/theories/ub_logic/total_adequacy.v
@@ -504,7 +504,7 @@ Theorem twp_total_ub_lift Σ `{ub_clutchGpreS Σ} (e : expr) (σ : state) (ε : 
   total_ub_lift (lim_exec (e, σ)) φ ε.
 Proof.
   intros Hwp.
-  eapply (step_fupdN_soundness_no_lc _ 0 0) => Hinv.
+  eapply pure_soundness, (step_fupdN_soundness_no_lc _ 0 0) => Hinv.
   iIntros "_".
   iMod (ghost_map_alloc σ.(heap)) as "[%γH [Hh _]]".
   iMod (ghost_map_alloc σ.(tapes)) as "[%γT [Ht _]]".

--- a/theories/ub_logic/ub_rules.v
+++ b/theories/ub_logic/ub_rules.v
@@ -1299,7 +1299,7 @@ Proof.
   iInduction i as [|i'] "IH" forall (suffix_remaining).
   - iIntros "Hwp"; iApply "Hwp".
     iRight. iSplitL "Htape".
-    + rewrite take_0 -app_nil_end. iFrame.
+    + rewrite take_0. rewrite app_nil_r. iFrame.
     + iApply ec_spend_irrel; last iFrame.
       rewrite /εR /fR /pos_to_nn /=; lra.
   - iIntros "Hwand".
@@ -1345,7 +1345,7 @@ Proof.
   iInduction i as [|i'] "IH" forall (suffix_remaining).
   - iIntros "Hwp"; iApply "Hwp".
     iRight. iSplitL "Htape".
-    + rewrite take_0 -app_nil_end. iFrame.
+    + rewrite take_0 app_nil_r. iFrame.
     + iApply ec_spend_irrel; last iFrame.
       rewrite /εR /fR /pos_to_nn /=; lra.
   - iIntros "Hwand".
@@ -1385,7 +1385,7 @@ Lemma twp_presample_amplify N z e E α Φ (ε : posreal) L (kwf: kwf N L) prefix
 Proof.
   iIntros (? ? Hl) "(Hcr & Htape & Hwp)".
   destruct suffix as [|s0 sr].
-  - iApply "Hwp". iLeft. rewrite -app_nil_end. iFrame.
+  - iApply "Hwp". iLeft. rewrite app_nil_r. iFrame.
   - remember (s0 :: sr) as suffix.
     assert (Hl_pos : (0 < L)%nat).
     { rewrite Hl Heqsuffix cons_length. lia. }
@@ -1408,7 +1408,7 @@ Lemma wp_presample_amplify N z e E α Φ (ε : posreal) L (kwf: kwf N L) prefix 
 Proof.
   iIntros (? ? Hl) "(Hcr & Htape & Hwp)".
   destruct suffix as [|s0 sr].
-  - iApply "Hwp". iLeft. rewrite -app_nil_end. iFrame.
+  - iApply "Hwp". iLeft. rewrite app_nil_r. iFrame.
   - remember (s0 :: sr) as suffix'.
     assert (Hl_pos : (0 < L)%nat).
     { rewrite Hl Heqsuffix' cons_length. lia. }
@@ -1667,10 +1667,10 @@ Proof.
   intros Hblocksize junk.
   rewrite /block_pad.
   rewrite repeat_length.
-  rewrite -PeanoNat.Nat.add_mod_idemp_l; [|lia].
-  rewrite -PeanoNat.Nat.add_mod; [|lia].
-  rewrite -PeanoNat.Nat.add_mod_idemp_l; [|lia].
-  rewrite -Nat.le_add_sub; [apply Nat.mod_same; lia|].
+  rewrite -Nat.Div0.add_mod_idemp_l.
+  rewrite -Nat.Div0.add_mod.
+  rewrite -Nat.Div0.add_mod_idemp_l.
+  rewrite -Nat.le_add_sub; [apply Nat.Div0.mod_same|].
   apply Nat.lt_le_incl.
   apply Nat.mod_bound_pos; [apply Nat.le_0_l | done].
 Qed.

--- a/theories/ub_logic/ub_tactics.v
+++ b/theories/ub_logic/ub_tactics.v
@@ -173,12 +173,12 @@ Tactic Notation "rel_pure_l" open_constr(ef) :=
       unify e' ef;
       eapply (tac_rel_pure_l K e');
       [reflexivity                  (** e = fill K e1 *)
-      |iSolveTC                     (** PureExec ϕ n e1 e2 *)
+      |tc_solve                     (** PureExec ϕ n e1 e2 *)
       | .. ]);
       [try solve_vals_compare_safe                (** φ *)
       |first [left; reflexivity
              | right; reflexivity]                  (** (m = n) ∨ (m = 0) *)
-      |iSolveTC                                     (** IntoLaters *)
+      |tc_solve                                     (** IntoLaters *)
       |simpl; reflexivity           (** eres = fill K e2 *)
       |rel_finish                   (** new goal *)]
   || fail "rel_pure_l: cannot find the reduct".
@@ -191,7 +191,7 @@ Tactic Notation "rel_pure_r" open_constr(ef) :=
       unify e' ef;
       eapply (tac_rel_pure_r K e');
       [reflexivity                  (** e = fill K e1 *)
-      |iSolveTC                     (** PureExec ϕ n e1 e2 *)
+      |tc_solve                     (** PureExec ϕ n e1 e2 *)
       |..]);
       [try solve_vals_compare_safe                (** φ *)
       |solve_ndisj        || fail 1 "rel_pure_r: cannot solve ↑specN ⊆ ?"
@@ -256,7 +256,7 @@ Tactic Notation "rel_load_l" :=
        eapply (tac_rel_load_l_simp K); first reflexivity)
     |fail 1 "rel_load_l: cannot find 'Load'"];
   (* the remaining goals are from tac_lel_load_l (except for the first one, which has already been solved by this point) *)
-  [iSolveTC             (** IntoLaters *)
+  [tc_solve             (** IntoLaters *)
   |solve_mapsto ()
   |reflexivity       (** eres = fill K v *)
   |rel_finish  (** new goal *)].
@@ -332,11 +332,11 @@ Tactic Notation "rel_store_l" :=
     [rel_reshape_cont_l ltac:(fun K e' =>
        eapply (tac_rel_store_l_simpl K);
        [reflexivity (** e = fill K (#l <- e') *)
-       |iSolveTC    (** e' is a value *)
+       |tc_solve    (** e' is a value *)
        |idtac..])
     |fail 1 "rel_store_l: cannot find 'Store'"];
   (* the remaining goals are from tac_rel_store_l (except for the first one, which has already been solved by this point) *)
-  [iSolveTC        (** IntoLaters *)
+  [tc_solve        (** IntoLaters *)
   |solve_mapsto ()
   |pm_reflexivity || fail "rel_store_l: this should not happen O-:"
   |reflexivity
@@ -352,7 +352,7 @@ Tactic Notation "rel_store_r" :=
   first
     [rel_reshape_cont_r ltac:(fun K e' =>
        eapply (tac_rel_store_r K);
-       [reflexivity|iSolveTC|idtac..])
+       [reflexivity|tc_solve|idtac..])
     |fail 1 "rel_store_r: cannot find 'Store'"];
   (* the remaining goals are from tac_rel_store_r (except for the first one, which has already been solved by this point) *)
   [solve_ndisj || fail "rel_store_r: cannot prove 'nclose specN ⊆ ?'"
@@ -385,10 +385,10 @@ Tactic Notation "rel_alloc_l" ident(l) "as" constr(H) :=
     [rel_reshape_cont_l ltac:(fun K e' =>
        eapply (tac_rel_alloc_l_simpl K);
        [reflexivity (** e = fill K (Alloc e') *)
-       |iSolveTC    (** e' is a value *)
+       |tc_solve    (** e' is a value *)
        |idtac..])
     |fail 1 "rel_alloc_l: cannot find 'Alloc'"];
-  [iSolveTC        (** IntoLaters *)
+  [tc_solve        (** IntoLaters *)
   |iIntros (l) H; rel_finish  (** new goal *)].
 
 Lemma tac_rel_alloc_r `{!clutchRGS Σ} K' ℶ E t' v' e t A :
@@ -408,7 +408,7 @@ Tactic Notation "rel_alloc_r" ident(l) "as" constr(H) :=
     [rel_reshape_cont_r ltac:(fun K e' =>
        eapply (tac_rel_alloc_r K);
        [reflexivity  (** t = K'[alloc t'] *)
-       |iSolveTC     (** t' is a value *)
+       |tc_solve     (** t' is a value *)
        |idtac..])
     |fail 1 "rel_alloc_r: cannot find 'Alloc'"];
   [solve_ndisj || fail "rel_alloc_r: cannot prove 'nclose specN ⊆ ?'"
@@ -447,11 +447,11 @@ Tactic Notation "rel_alloctape_l" ident(l) "as" constr(H) :=
   first
     [rel_reshape_cont_l ltac:(fun K e' =>
        eapply (tac_rel_alloctape_l_simpl K);
-       [iSolveTC (** TCEq N (Z.to_nat z) → *)
+       [tc_solve (** TCEq N (Z.to_nat z) → *)
        |reflexivity (** e = fill K (Alloc e') *)
        |idtac..])
     |fail 1 "rel_alloctape_l: cannot find 'AllocTape'"];
-  [iSolveTC        (** IntoLaters *)
+  [tc_solve        (** IntoLaters *)
   |iIntros (l) H; rewrite ?Nat2Z.id; rel_finish  (** new goal *)].
 
 Lemma tac_rel_alloctape_r `{!clutchRGS Σ} K' ℶ E e N z t A :
@@ -467,7 +467,7 @@ Tactic Notation "rel_alloctape_r" ident(l) "as" constr(H) :=
   first
     [rel_reshape_cont_r ltac:(fun K e' =>
        eapply (tac_rel_alloctape_r K);
-       [iSolveTC
+       [tc_solve
        |reflexivity  (** t = K'[alloc t'] *)
        |idtac..])
     |fail 1 "rel_alloctape_r: cannot find 'AllocTape'"];
@@ -535,7 +535,7 @@ Tactic Notation "rel_rand_l" :=
        eapply (tac_rel_rand_l K); [|reflexivity|..])
     |fail 1 "rel_rand_l: cannot find 'Rand'"];
   (* the remaining goals are from tac_rel_rand_l (except for the first one, which has already been solved by this point) *)
-  [iSolveTC
+  [tc_solve
   |solve_mapsto ()
   |pm_reflexivity || fail "rel_rand_l: this should not happen O-:"
   |reflexivity
@@ -552,7 +552,7 @@ Tactic Notation "rel_rand_r" :=
        eapply (tac_rel_rand_r K); [|reflexivity|..])
     |fail 1 "rel_rand_r: cannot find 'Rand'"];
   (* the remaining goals are from tac_rel_rand_r (except for the first one, which has already been solved by this point) *)
-  [iSolveTC
+  [tc_solve
   |solve_ndisj || fail "rel_rand_r: cannot prove 'nclose specN ⊆ ?'"
   |solve_mapsto ()
   |pm_reflexivity || fail "rel_rand_r: this should not happen O-:"

--- a/theories/ub_logic/ub_tactics.v
+++ b/theories/ub_logic/ub_tactics.v
@@ -524,7 +524,6 @@ Proof.
   apply bi.wand_elim_l.
 Qed.
 
-Local Set Warnings "-cast-in-pattern".
 Tactic Notation "rel_rand_l" :=
   let solve_mapsto _ := 
     let α := match goal with |- _ = Some (_, (?α ↪ _)%I) => α end in

--- a/theories/ub_logic/ub_weakestpre.v
+++ b/theories/ub_logic/ub_weakestpre.v
@@ -21,7 +21,7 @@ Local Open Scope NNR_scope.
     error (i.e. terminating in a state that does not satisfy the postcondition)
  *)
 Class irisGS (Λ : language) (Σ : gFunctors) := IrisG {
-  iris_invGS :> invGS_gen HasNoLc Σ;
+  iris_invGS :: invGS_gen HasNoLc Σ;
   state_interp : state Λ → iProp Σ;
   err_interp : nonnegreal → iProp Σ;
 }.
@@ -864,10 +864,10 @@ Proof.
   apply least_fixpoint_ne_outer; [|done].
   intros ? [? []]. rewrite /exec_ub_pre.
   do 16 f_equiv.
-  { f_contractive. do 3 f_equiv. rewrite IH; [done|lia|].
+  { f_contractive_fin. do 3 f_equiv. rewrite IH; [done|lia|].
     intros ?. eapply dist_S, HΦ. }
   { rewrite /exec_stutter.
-    do 12 f_equiv. f_contractive.
+    do 12 f_equiv. f_contractive_fin.
     rewrite IH; [done|lia|].
     intros ?. eapply dist_S, HΦ. }
 Qed.


### PR DESCRIPTION
To get this working on your machine, it should be enough to check out the `main` branch, pull, and upgrade your dependencies (I'm assuming they're installed via `opam`) via `opam install --deps-only .` , which will pull in the new version of Coq, Iris (4.1.0), and stdpp (1.9.0). Confirm the upgrade, `make clean`, and re-build via `make` as usual.