### PR TITLE
Reducible

### DIFF
--- a/theories/app_rel_logic/adequacy.v
+++ b/theories/app_rel_logic/adequacy.v
@@ -34,12 +34,11 @@ Section adequacy.
 
   Lemma exec_coupl_erasure (e1 : expr) (σ1 : state) (e1' : expr) (σ1' : state) (n : nat) φ (ε : nonnegreal) :
     to_val e1 = None →
-    reducible (e1, σ1) ->
     exec_coupl e1 σ1 e1' σ1' (λ '(e2, σ2) '(e2', σ2') ε',
         |={∅}▷=>^(S n) ⌜ARcoupl (exec n (e2, σ2)) (lim_exec (e2', σ2')) φ ε'⌝) ε
     ⊢ |={∅}▷=>^(S n) ⌜ARcoupl (exec (S n) (e1, σ1)) (lim_exec (e1', σ1')) φ ε⌝.
   Proof.
-    iIntros (Hv Hred) "Hexec".
+    iIntros (Hv) "Hexec".
     iAssert (⌜to_val e1 = None⌝)%I as "-#H"; [done|]. iRevert "Hexec H".
     rewrite /exec_coupl /exec_coupl'.
     set (Φ := (λ '(((e1, σ1),(e1', σ1')),ε'),
@@ -216,7 +215,7 @@ Section adequacy.
         apply (ARcoupl_mon_grading _ _ _ 0); [apply cond_nonneg | ].
         by apply ARcoupl_dret.
       + rewrite wp_unfold /wp_pre /= Heq.
-        iMod ("Hwp" with "[$]") as "(%Hred & Hcpl)".
+        iMod ("Hwp" with "[$]") as "Hcpl".
         iModIntro.
         assert ((prim_step e σ) = (step (e, σ))) as h => //. rewrite h. clear h.
         rewrite -exec_Sn_not_final ; [|auto].

--- a/theories/app_rel_logic/app_weakestpre.v
+++ b/theories/app_rel_logic/app_weakestpre.v
@@ -445,57 +445,6 @@ Section exec_coupl.
     done.
   Qed.
 
-(*
-  Lemma exec_coupl_reducible e e' σ σ' Z :
-    exec_coupl e σ e' σ' Z ={∅}=∗ ⌜reducible e σ⌝.
-  Proof.
-    rewrite /exec_coupl /exec_coupl'.
-    set (Φ := (λ x, |={∅}=> ⌜reducible x.1.1 x.1.2⌝)%I : prodO cfgO cfgO → iPropI Σ).
-    assert (NonExpansive Φ).
-    { intros n ((?&?)&(?&?)) ((?&?)&(?&?)) [[[=] [=]] [[=] [=]]]. by simplify_eq. }
-    iPoseProof (least_fixpoint_iter (exec_coupl_pre Z) Φ
-                 with "[]") as "H"; last first.
-    { done. }
-    iIntros "!>" (([e1 σ1] & [e1' σ1'])). rewrite /exec_coupl_pre.
-    iIntros "[(% & % & % & H) | [(% & % & % & H) | [(% & % & %Hcpl & H) | [H | [H | H]]]]] /=";
-      [done|done| | | |].
-    - eapply Rcoupl_pos_R in Hcpl.
-      eapply Rcoupl_inhabited_l in Hcpl as ([] & [] & ? & [= -> ->]%dret_pos & ?); last first.
-      { rewrite dret_mass; lra. }
-      by iMod ("H" with "[//]").
-    - iDestruct (big_orL_mono _ (λ n αs, |={∅}=> ⌜reducible (e1, σ1)⌝)%I  with "H") as "H".
-      { iIntros (? α' ?%elem_of_list_lookup_2) "(% & % & _)". eauto. }
-      iInduction (get_active σ1') as [| α'] "IH"; [done|].
-      rewrite big_orL_cons.
-      iDestruct "H" as "[? | H]"; [done|].
-      by iApply "IH".
-    - iDestruct (big_orL_mono _ (λ n αs, |={∅}=> ⌜reducible (e1, σ1)⌝)%I  with "H") as "H".
-      { iIntros (? α' ?%elem_of_list_lookup_2) "(% & %Hcpl & H)".
-        eapply Rcoupl_pos_R in Hcpl.
-        eapply Rcoupl_inhabited_l in Hcpl as (σ2 & [] & ? & ? & ?); last first.
-        { rewrite state_step_mass //. lra. }
-        iApply (pure_impl_1 (reducible e1 σ2)).
-        { iPureIntro. by eapply state_step_reducible. }
-        by iMod ("H" with "[//]"). }
-      iInduction (get_active σ1) as [| α] "IH"; [done|].
-      rewrite big_orL_cons.
-      iDestruct "H" as "[? | H]"; [done|].
-      by iApply "IH".
-    - iDestruct (big_orL_mono _ (λ n αs, |={∅}=> ⌜reducible (e1, σ1)⌝)%I  with "H") as "H".
-      { iIntros (? [α1 α2] [? ?]%elem_of_list_lookup_2%elem_of_list_prod_1) "(% & %Hcpl & H)".
-        eapply Rcoupl_pos_R in Hcpl.
-        eapply Rcoupl_inhabited_l in Hcpl as (σ2 &?&?& Hs &?); last first.
-        { rewrite state_step_mass //. lra. }
-        iApply (pure_impl_1 (reducible e1 σ2)).
-        { iPureIntro. by eapply state_step_reducible. }
-        by iMod ("H" with "[//]"). }
-      iInduction (list_prod (get_active σ1) (get_active σ1')) as [| [α α']] "IH"; [done|].
-      rewrite big_orL_cons.
-      iDestruct "H" as "[? | H]"; [done|].
-      by iApply "IH".
-  Qed.
-*)
-
   Lemma exec_coupl_det_r n e1 σ1 e1' σ1' e2' σ2' Z (ε : nonnegreal) :
     pexec n (e1', σ1') (e2', σ2') = 1 →
     exec_coupl e1 σ1 e2' σ2' Z ε -∗
@@ -513,6 +462,43 @@ Section exec_coupl.
     rewrite Hexec in H. by apply dret_pos in H as [= -> ->].
   Qed.
 
+
+  (* probably not true *)
+  (* Lemma exec_coupl_reducible e1 σ1 e2 σ2 Z ε: *)
+  (*   exec_coupl e1 σ1 e2 σ2 Z ε ={∅}=∗ ⌜reducible (e1, σ1)⌝. *)
+  (* Proof. *)
+  (*   iIntros "H". *)
+  (*   set (Φ := (λ x, |={∅}=> ⌜reducible (x.1.1.1, x.1.1.2)⌝)%I *)
+  (*          : prodO (prodO cfgO cfgO) NNRO → iPropI Σ). *)
+  (*   iPoseProof (least_fixpoint_ind (exec_coupl_pre Z) Φ) as "IH". rewrite /exec_coupl/exec_coupl'. *)
+  (*   iApply ("IH" with "[][$]"). *)
+  (*   iModIntro. iIntros (([[e1' σ1'][e2' σ2']]&?)). rewrite /Φ. simpl. *)
+  (*   iIntros "[H|[H|[H|[H|[H|H]]]]]". *)
+  (*   - iDestruct "H" as "(%&%&%&%&%&H)". done. *)
+  (*   - iDestruct "H" as "(%&%&%&%&%&H)". done. *)
+  (*   - iDestruct "H" as "(%&%&%&%&%&%Hcpl&H)". *)
+  (*     eapply ARcoupl_pos_R in Hcpl. admit. *)
+  (*   - iDestruct (big_orL_mono _ (λ n αs, |={∅}=> ⌜reducible (e1', σ1')⌝)%I  with "H") as "H". *)
+  (*     { iIntros (? α' ?%elem_of_list_lookup_2) "(% & % & % & %& % & H)". eauto. } *)
+  (*     iInduction (get_active σ2') as [| α'] "IH'"; [done|]. *)
+  (*     rewrite big_orL_cons. *)
+  (*     iDestruct "H" as "[H | H]";  [done|]. *)
+  (*     by iApply "IH'". *)
+  (*   - iDestruct (big_orL_mono _ (λ n αs, |={∅}=> ⌜reducible (e1', σ1')⌝)%I  with "H") as "H". *)
+  (*     { iIntros (? α' ?%elem_of_list_lookup_2) "(% & % & % & %& % & H)". eauto. admit. } *)
+  (*     iInduction (get_active σ1') as [| α'] "IH'"; [done|]. *)
+  (*     rewrite big_orL_cons. *)
+  (*     iDestruct "H" as "[H | H]";  [done|]. *)
+  (*     by iApply "IH'". *)
+  (*   - iDestruct (big_orL_mono _ (λ n αs, |={∅}=> ⌜reducible (e1', σ1')⌝)%I  with "H") as "H". *)
+  (*     { iIntros (? α' ?%elem_of_list_lookup_2) "(% & % & % & %& % & H)". eauto. admit. } *)
+  (*     iInduction (list_prod (get_active σ1') (get_active σ2')) as [| α'] "IH'"; [done|]. *)
+  (*     rewrite big_orL_cons. *)
+  (*     iDestruct "H" as "[H | H]";  [done|]. *)
+  (*     by iApply "IH'". *)
+  (* Admitted. *)
+    
+  
 End exec_coupl.
 
 (** * The weakest precondition  *)
@@ -523,7 +509,6 @@ Definition wp_pre `{!irisGS Λ Σ}
   | Some v => |={E}=> Φ v
   | None => ∀ σ1 e1' σ1' ε,
       state_interp σ1 ∗ spec_interp (e1', σ1') ∗ err_interp ε ={E,∅}=∗
-      ⌜reducible (e1, σ1)⌝ ∗
       exec_coupl e1 σ1 e1' σ1' (λ '(e2, σ2) '(e2', σ2') ε2,
         ▷ |={∅,E}=> state_interp σ2 ∗ spec_interp (e2', σ2') ∗ err_interp ε2 ∗ wp E e2 Φ) ε
 end%I.
@@ -531,7 +516,7 @@ end%I.
 Local Instance wp_pre_contractive `{!irisGS Λ Σ} : Contractive wp_pre.
 Proof.
   rewrite /wp_pre /= => n wp wp' Hwp E e1 Φ.
-  do 12 f_equiv.
+  do 11 f_equiv.
   apply least_fixpoint_ne_outer; [|done].
   intros ? [[[] []] ?]. rewrite /exec_coupl_pre.
   do 15 f_equiv.
@@ -569,7 +554,7 @@ Global Instance wp_ne s E e n :
 Proof.
   revert e. induction (lt_wf n) as [n _ IH]=> e Φ Ψ HΦ.
   rewrite !wp_unfold /wp_pre /=.
-  do 12 f_equiv.
+  do 11 f_equiv.
   apply least_fixpoint_ne_outer; [|done].
   intros ? [[[] []] ?]. rewrite /exec_coupl_pre.
   do 15 f_equiv.
@@ -590,7 +575,7 @@ Global Instance wp_contractive s E e n :
   Proper (pointwise_relation _ (dist_later n) ==> dist n) (wp (PROP:=iProp Σ) s E e).
 Proof.
   intros He Φ Ψ HΦ. rewrite !wp_unfold /wp_pre He /=.
-  do 11 f_equiv.
+  do 10 f_equiv.
   apply least_fixpoint_ne_outer; [|done].
   intros ? [[[] []] ?]. rewrite /exec_coupl_pre.
   do 15 f_equiv.
@@ -612,7 +597,7 @@ Proof.
   { iApply ("HΦ" with "[> -]"). by iApply (fupd_mask_mono E1 _). }
   iIntros (σ1 e1' σ1' ε) "[Hσ [Hs Herr]]".
   iMod (fupd_mask_subseteq E1) as "Hclose"; first done.
-  iMod ("H" with "[$]") as "[? H]".
+  iMod ("H" with "[$]") as "H".
   iModIntro.
   iFrame.
   iApply (exec_coupl_mono with "[Hclose HΦ] H").
@@ -632,14 +617,14 @@ Qed.
 Lemma wp_fupd s E e Φ : WP e @ s; E {{ v, |={E}=> Φ v }} ⊢ WP e @ s; E {{ Φ }}.
 Proof. iIntros "H". iApply (wp_strong_mono E with "H"); auto. Qed.
 
-Lemma wp_atomic s E1 E2 e Φ `{!Atomic WeaklyAtomic e} :
+Lemma wp_atomic s E1 E2 e Φ `{!Atomic StronglyAtomic e} :
   (|={E1,E2}=> WP e @ s; E2 {{ v, |={E2,E1}=> Φ v }}) ⊢ WP e @ s; E1 {{ Φ }}.
 Proof.
   iIntros "H". rewrite !wp_unfold /wp_pre.
   destruct (to_val e) as [v|] eqn:He.
   { by iDestruct "H" as ">>> $". }
   iIntros (σ1 e1' σ1' ε) "[Hσ [Hs Herr]]". iMod "H".
-  iMod ("H" with "[$]") as "[? H]".
+  iMod ("H" with "[$]") as "H".
   iModIntro.
   iFrame.
   iDestruct (exec_coupl_strengthen with "H") as "H".
@@ -652,14 +637,10 @@ Proof.
   destruct (to_val e2) as [v2|] eqn:He2.
   - iDestruct "H" as ">> $". by iFrame.
   - iMod ("H" with "[$]") as "H".
-    iDestruct "H" as (?) "H".
-    pose proof (atomic σ e2 σ2 Hstep) as H3.
-    case_match.
-    + rewrite /is_Some in H3.
-      destruct H3.
-      simplify_eq.
-    + apply not_reducible in H3.
-      done.
+    pose proof (atomic σ e2 σ2 Hstep) as H3. simpl in H3.
+    rewrite /is_Some in H3.
+    destruct H3.
+    simplify_eq.
 Qed.
 
 Lemma wp_step_fupd s E1 E2 e P Φ :
@@ -668,7 +649,7 @@ Lemma wp_step_fupd s E1 E2 e P Φ :
 Proof.
   rewrite !wp_unfold /wp_pre. iIntros (-> ?) "HR H".
   iIntros (σ1 e1' σ1' ε) "[Hσ [Hs Hε]]". iMod "HR".
-  iMod ("H" with "[$Hσ $Hs $Hε]") as "[? H]".
+  iMod ("H" with "[$Hσ $Hs $Hε]") as "H".
   iModIntro.
   iFrame.
   iApply (exec_coupl_mono with "[HR] H").
@@ -689,11 +670,8 @@ Proof.
   { apply of_to_val in He as <-. by iApply fupd_wp. }
   rewrite wp_unfold /wp_pre fill_not_val /=; [|done].
   iIntros (σ1 e1' σ1' ε) "[Hσ [Hs Herr]]".
-  iMod ("H" with "[$Hσ $Hs $Herr]") as "[%Hred H]".
+  iMod ("H" with "[$Hσ $Hs $Herr]") as "H".
   iModIntro.
-  iSplit.
-  - iPureIntro.
-    apply reducible_fill; auto.
   - iApply exec_coupl_bind; [done|].
   iApply (exec_coupl_mono with "[] H").
   iIntros ([e2 σ2] [e2' σ2'] ε') "H".
@@ -818,7 +796,7 @@ Section proofmode_classes.
   Qed.
 
   Global Instance elim_modal_fupd_wp_atomic p s E1 E2 e P Φ :
-    ElimModal (Atomic WeaklyAtomic e) p false
+    ElimModal (Atomic StronglyAtomic e) p false
             (|={E1,E2}=> P) P
             (WP e @ s; E1 {{ Φ }}) (WP e @ s; E2 {{ v, |={E2,E1}=> Φ v }})%I | 100.
   Proof.
@@ -831,7 +809,7 @@ Section proofmode_classes.
   Proof. by rewrite /AddModal fupd_frame_r wand_elim_r fupd_wp. Qed.
 
   Global Instance elim_acc_wp_atomic {X} E1 E2 α β γ e s Φ :
-    ElimAcc (X:=X) (Atomic WeaklyAtomic e)
+    ElimAcc (X:=X) (Atomic StronglyAtomic e)
             (fupd E1 E2) (fupd E2 E1)
             α β γ (WP e @ s; E1 {{ Φ }})
             (λ x, WP e @ s; E2 {{ v, |={E2}=> β x ∗ (γ x -∗? Φ v) }})%I | 100.

--- a/theories/app_rel_logic/app_weakestpre.v
+++ b/theories/app_rel_logic/app_weakestpre.v
@@ -461,42 +461,6 @@ Section exec_coupl.
     iIntros (e2'' σ2'' (_ & _ & H)).
     rewrite Hexec in H. by apply dret_pos in H as [= -> ->].
   Qed.
-
-
-  (* probably not true *)
-  (* Lemma exec_coupl_reducible e1 σ1 e2 σ2 Z ε: *)
-  (*   exec_coupl e1 σ1 e2 σ2 Z ε ={∅}=∗ ⌜reducible (e1, σ1)⌝. *)
-  (* Proof. *)
-  (*   iIntros "H". *)
-  (*   set (Φ := (λ x, |={∅}=> ⌜reducible (x.1.1.1, x.1.1.2)⌝)%I *)
-  (*          : prodO (prodO cfgO cfgO) NNRO → iPropI Σ). *)
-  (*   iPoseProof (least_fixpoint_ind (exec_coupl_pre Z) Φ) as "IH". rewrite /exec_coupl/exec_coupl'. *)
-  (*   iApply ("IH" with "[][$]"). *)
-  (*   iModIntro. iIntros (([[e1' σ1'][e2' σ2']]&?)). rewrite /Φ. simpl. *)
-  (*   iIntros "[H|[H|[H|[H|[H|H]]]]]". *)
-  (*   - iDestruct "H" as "(%&%&%&%&%&H)". done. *)
-  (*   - iDestruct "H" as "(%&%&%&%&%&H)". done. *)
-  (*   - iDestruct "H" as "(%&%&%&%&%&%Hcpl&H)". *)
-  (*     eapply ARcoupl_pos_R in Hcpl. admit. *)
-  (*   - iDestruct (big_orL_mono _ (λ n αs, |={∅}=> ⌜reducible (e1', σ1')⌝)%I  with "H") as "H". *)
-  (*     { iIntros (? α' ?%elem_of_list_lookup_2) "(% & % & % & %& % & H)". eauto. } *)
-  (*     iInduction (get_active σ2') as [| α'] "IH'"; [done|]. *)
-  (*     rewrite big_orL_cons. *)
-  (*     iDestruct "H" as "[H | H]";  [done|]. *)
-  (*     by iApply "IH'". *)
-  (*   - iDestruct (big_orL_mono _ (λ n αs, |={∅}=> ⌜reducible (e1', σ1')⌝)%I  with "H") as "H". *)
-  (*     { iIntros (? α' ?%elem_of_list_lookup_2) "(% & % & % & %& % & H)". eauto. admit. } *)
-  (*     iInduction (get_active σ1') as [| α'] "IH'"; [done|]. *)
-  (*     rewrite big_orL_cons. *)
-  (*     iDestruct "H" as "[H | H]";  [done|]. *)
-  (*     by iApply "IH'". *)
-  (*   - iDestruct (big_orL_mono _ (λ n αs, |={∅}=> ⌜reducible (e1', σ1')⌝)%I  with "H") as "H". *)
-  (*     { iIntros (? α' ?%elem_of_list_lookup_2) "(% & % & % & %& % & H)". eauto. admit. } *)
-  (*     iInduction (list_prod (get_active σ1') (get_active σ2')) as [| α'] "IH'"; [done|]. *)
-  (*     rewrite big_orL_cons. *)
-  (*     iDestruct "H" as "[H | H]";  [done|]. *)
-  (*     by iApply "IH'". *)
-  (* Admitted. *)
     
   
 End exec_coupl.

--- a/theories/app_rel_logic/coupling_rules.v
+++ b/theories/app_rel_logic/coupling_rules.v
@@ -39,7 +39,6 @@ Section rules.
     iDestruct (ghost_map_lookup with "Htapes Hαₛ") as %?.
     iDestruct (ghost_map_lookup with "Ht1 Hα") as %?.
     iApply fupd_mask_intro; [set_solver|]; iIntros "Hclose'".
-    iSplitR ; [done|].
     (* Get up to speed with the spec resource (tracked in spec_ctx) *)
     iApply exec_coupl_det_r; [done|].
     (* split ε_now into ε + (ε_now - ε) *)
@@ -78,7 +77,7 @@ Section rules.
     iSpecialize ("Hwp" $! n m nm with "[$Hα $Hαₛ]").
     rewrite !wp_unfold /wp_pre /= He.
     iMod ("Hwp" $! (state_upd_tapes <[α:=(N; ns ++ [n]) : tape]> _)
-           with "[$Hh1 $Hauth2 $Ht1 $Hε2]") as "[Hred Hwp]".
+           with "[$Hh1 $Hauth2 $Ht1 $Hε2]") as "Hwp".
     iModIntro. done.
   Qed.
 
@@ -105,7 +104,6 @@ Section rules.
     iDestruct (ghost_map_lookup with "Htapes Hαₛ") as %?.
     iDestruct (ghost_map_lookup with "Ht1 Hα") as %?.
     iApply fupd_mask_intro; [set_solver|]; iIntros "Hclose'".
-    iSplitR ; [done|].
     (* Get up to speed with the spec resource (tracked in spec_ctx) *)
     iApply exec_coupl_det_r; [done|].
     (* split ε_now into ε + (ε_now - ε) *)
@@ -144,7 +142,7 @@ Section rules.
     iSpecialize ("Hwp" $! n m nm with "[$Hα $Hαₛ]").
     rewrite !wp_unfold /wp_pre /= He.
     iMod ("Hwp" $! (state_upd_tapes <[α:=(N; ns ++ [n]) : tape]> _)
-           with "[$Hh1 $Hauth2 $Ht1 $Hε2]") as "[Hred Hwp]".
+           with "[$Hh1 $Hauth2 $Ht1 $Hε2]") as "Hwp".
     iModIntro. done.
   Qed.
 
@@ -163,8 +161,6 @@ Section rules.
     iInv specN as (ρ' e0' σ0' n_spec_steps) ">(Hspec0 & %Hexec & Hauth & Hheap & Htapes)" "Hclose".
     iDestruct (spec_interp_auth_frag_agree with "Hauth2 Hspec0") as %<-.
     iApply fupd_mask_intro; [set_solver|]; iIntros "Hclose'".
-    iSplit.
-    { iPureIntro. eapply head_prim_reducible; eauto with head_step. }
     (* Get up to speed with the spec resource (tracked in spec_ctx) *)
     iApply exec_coupl_det_r; [done|].
     iDestruct (ec_supply_bound with "Hε2 Hε") as %Hle.
@@ -223,8 +219,6 @@ Section rules.
     iDestruct (spec_prog_auth_frag_agree with "Hauth Hr") as %->.
     iDestruct (spec_interp_auth_frag_agree with "Hauth2 Hspec0") as %<-.
     iApply fupd_mask_intro; [set_solver|]; iIntros "Hclose'".
-    iSplit.
-    { iPureIntro. eapply head_prim_reducible; eauto with head_step. }
     iDestruct (ec_supply_bound with "Hε2 Hε") as %Hle.
     set (ε' := nnreal_minus ε_now ε Hle ).
     replace ε_now with (nnreal_plus ε ε'); last first.
@@ -290,11 +284,6 @@ Section rules.
     iDestruct (spec_prog_auth_frag_agree with "Hauth Hr") as %->.
     iDestruct (spec_interp_auth_frag_agree with "Hauth2 Hspec0") as %<-.
     iApply fupd_mask_intro; [set_solver|]; iIntros "Hclose'".
-    iSplit.
-    { iPureIntro. apply head_prim_reducible.
-      eexists (Val #0%fin, σ1).
-      apply head_step_support_equiv_rel.
-      by eapply (RandNoTapeS _ _ 0%fin). }
     iDestruct (ec_supply_bound with "Hε2 Hε") as %Hle.
     set (ε' := nnreal_minus ε_now ε Hle ).
     replace ε_now with (nnreal_plus ε ε'); last first.

--- a/theories/app_rel_logic/ectx_lifting.v
+++ b/theories/app_rel_logic/ectx_lifting.v
@@ -26,9 +26,7 @@ Lemma wp_lift_head_step_fupd_couple {E Φ} e1 :
 Proof.
   iIntros (?) "H". iApply wp_lift_step_fupd_couple; [done |].
   iIntros (σ1 e1' σ1' ε) "Hσ".
-  iMod ("H" with "Hσ") as "[% H]"; iModIntro.
-  iSplit; [|done].
-  iPureIntro. by apply head_prim_reducible.
+  iMod ("H" with "Hσ") as "[% H]"; iModIntro. done.
 Qed.
 
 Lemma wp_lift_head_step {E Φ} e1 :

--- a/theories/app_rel_logic/lifting.v
+++ b/theories/app_rel_logic/lifting.v
@@ -21,7 +21,6 @@ Lemma wp_lift_step_fupd_couple E Φ e1 :
   (∀ σ1 e1' σ1' ε,
     state_interp σ1 ∗ spec_interp (e1', σ1') ∗ err_interp ε
     ={E,∅}=∗
-    ⌜reducible (e1, σ1)⌝ ∗
     (exec_coupl e1 σ1 e1' σ1' (λ '(e2, σ2) '(e2', σ2') ε2,
       ▷ |={∅,E}=> state_interp σ2 ∗ spec_interp (e2', σ2') ∗ err_interp ε2 ∗ WP e2 @ E {{ Φ }}) ε))
   ⊢ WP e1 @ E {{ Φ }}.
@@ -43,7 +42,6 @@ Proof.
   iApply wp_lift_step_fupd_couple; [done|].
   iIntros (σ1 e1' σ1' ε) "[Hσ [Hρ Hε]]".
   iMod ("H" with "Hσ") as "[%Hs H]". iModIntro.
-  iSplit; [done|].
   replace (ε) with ((nnreal_zero + ε)%NNR) at 2; last first.
   {
     rewrite /nnreal_plus/=.

--- a/theories/app_rel_logic/spec_rules.v
+++ b/theories/app_rel_logic/spec_rules.v
@@ -159,7 +159,6 @@ Section rules.
     iDestruct (spec_interp_auth_frag_agree with "Hauth2 Hspec0") as %<-.
     iDestruct (spec_prog_auth_frag_agree with "Hauth Hj") as %->.
     iApply fupd_mask_intro; [set_solver|]; iIntros "Hclose'".
-    iSplitR ; [done|].
     replace (ε) with (nnreal_plus nnreal_zero ε)
       by by apply nnreal_ext => /=; lra.
     iApply exec_coupl_det_r; [done|].
@@ -192,7 +191,6 @@ Section rules.
     replace (nnreal_plus nnreal_zero ε) with (ε)
       by by apply nnreal_ext => /= ; lra.
     iModIntro.
-    iDestruct "Hwp" as "[hred Hwp]".
     done.
   Qed.
 
@@ -214,7 +212,6 @@ Section rules.
     iDestruct (ghost_map_lookup with "Htapes Hα") as %Hαsome.
     iDestruct (spec_prog_auth_frag_agree with "Hauth Hj") as %->.
     iApply fupd_mask_intro; [set_solver|]; iIntros "Hclose'".
-    iSplitR; [done|].
     replace (ε) with (nnreal_plus nnreal_zero ε)
       by by apply nnreal_ext => /=; lra.
     iApply exec_coupl_det_r; [done|].
@@ -248,7 +245,6 @@ Section rules.
     replace (nnreal_plus nnreal_zero ε) with (ε)
       by by apply nnreal_ext => /= ; lra.
     iModIntro.
-    iDestruct "Hwp" as "[hred Hwp]".
     done.
   Qed.
 
@@ -271,7 +267,6 @@ Section rules.
     iDestruct (ghost_map_lookup with "Htapes Hα") as %Hαsome.
     iDestruct (spec_prog_auth_frag_agree with "Hauth Hj") as %->.
     iApply fupd_mask_intro; [set_solver|]; iIntros "Hclose'".
-    iSplitR; [done|].
     replace (ε) with (nnreal_plus nnreal_zero ε)
       by by apply nnreal_ext => /=; lra.
     iApply exec_coupl_det_r; [done|].
@@ -306,7 +301,6 @@ Section rules.
     replace (nnreal_plus nnreal_zero ε) with (ε)
       by by apply nnreal_ext => /= ; lra.
     iModIntro.
-    iDestruct "Hwp" as "[hred Hwp]".
     done.
   Qed.
 

--- a/theories/prob/couplings_app.v
+++ b/theories/prob/couplings_app.v
@@ -317,29 +317,28 @@ Qed.
     exists μ; split; [split | ]; auto.
   Qed.
   Definition Rcoupl_impl μ1 μ2 R S H RC := Rcoupl_weaken μ1 μ2 R S RC H.
+*)
 
-  Lemma Rcoupl_inhabited_l (μ1 : distr A) (μ2 : distr B) R :
-    Rcoupl μ1 μ2 R →
-    SeriesC μ1 > 0 →
-    ∃ a b, R a b.
-  Proof.
-    intros [μ [Hcpl HR]] Hz.
-    assert (SeriesC μ > 0) as Hsup by by erewrite isCoupl_mass_l.
-    apply SeriesC_gtz_ex in Hsup as [[a b] Hμ]; [|done].
-    eauto.
-  Qed.
+  (* Lemma ARcoupl_inhabited_l (μ1 : distr A) (μ2 : distr B) R ε: *)
+  (*   ARcoupl μ1 μ2 R ε→ *)
+  (*   SeriesC μ1 > 0 → *)
+  (*   ∃ a b, R a b. *)
+  (* Proof. *)
+  (*   rewrite /ARcoupl. *)
+  (*   intros Ha Hz. *)
+  (* Admitted. *)
 
-  Lemma Rcoupl_inhabited_r (μ1 : distr A) (μ2 : distr B) R :
-    Rcoupl μ1 μ2 R →
-    SeriesC μ2 > 0 →
-    ∃ a b, R a b.
-  Proof.
-    intros [μ [Hcpl HR]] Hz.
-    assert (SeriesC μ > 0) as Hsup by by erewrite isCoupl_mass_r.
-    apply SeriesC_gtz_ex in Hsup as [[a b] Hμ]; [|done].
-    eauto.
-  Qed.
- *)
+  (* Lemma Rcoupl_inhabited_r (μ1 : distr A) (μ2 : distr B) R : *)
+  (*   Rcoupl μ1 μ2 R → *)
+  (*   SeriesC μ2 > 0 → *)
+  (*   ∃ a b, R a b. *)
+  (* Proof. *)
+  (*   intros [μ [Hcpl HR]] Hz. *)
+  (*   assert (SeriesC μ > 0) as Hsup by by erewrite isCoupl_mass_r. *)
+  (*   apply SeriesC_gtz_ex in Hsup as [[a b] Hμ]; [|done]. *)
+  (*   eauto. *)
+  (* Qed. *)
+ 
 
 End couplings_theory.
 


### PR DESCRIPTION
This is a proposal to remove the `reducible` constraint in the `exec_coupl` modality of the app relational logic. 
Note that this is to be consistent with all other logics we have, i.e. Clutch, Caliper, and Eris, where the `reducible` constraint is not in the `exec_ub` or `exec_coupl` modality.

For Clutch, this is not a problem since `exec_coupl` implies `reducibility`
However, this is NOT true for other logics. The fix is that we change the lemma of `wp_atomic` to require `StronglyAtomic` instead of `WeaklyAtomic`

