### PR TITLE
WIP: try to generate html from coqdocjs

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -39,8 +39,14 @@ jobs:
           before_script: |
             sudo chown -R coq:coq . # workaround a permission issue
           script: |
+            startGroup Clone coqdocjs
+              git clone https://github.com/ahuoguo/coqdocjs.git
+            endGroup
             startGroup Build
               make -j2
+            endGroup
+            startGroup HTML Build
+              make -f Makefile.ci -j2
             endGroup
           uninstall: |
             make clean
@@ -48,3 +54,19 @@ jobs:
         # to avoid a warning at cleanup time
         if: ${{ always() }}
         run: sudo chown -R 1001:116 .
+      - name: Upload html as artifact
+        if: always()
+        uses: actions/upload-pages-artifact@v1
+        with:
+          path: html
+
+  deploy:
+    needs: build
+    runs-on: ubuntu-latest
+    if: github.ref == 'refs/heads/main'
+    permissions:
+      pages: write
+      id-token: write
+    steps:
+      - name: Deploy to GitHub Pages
+        uses: actions/deploy-pages@v2

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -55,18 +55,20 @@ jobs:
         if: ${{ always() }}
         run: sudo chown -R 1001:116 .
       - name: Upload html as artifact
-        if: always()
-        uses: actions/upload-pages-artifact@v1
+        uses: actions/upload-pages-artifact@v3
         with:
           path: html
 
   deploy:
+    environment:
+      name: github-pages
+      url: ${{ steps.deployment.outputs.page_url }}
     needs: build
-    runs-on: ubuntu-latest
-    if: github.ref == 'refs/heads/main'
     permissions:
       pages: write
       id-token: write
+    runs-on: ubuntu-latest
     steps:
-      - name: Deploy to GitHub Pages
-        uses: actions/deploy-pages@v2
+      - name: deploy to github pages
+        id: deployment
+        uses: actions/deploy-pages@v4

--- a/Makefile.ci
+++ b/Makefile.ci
@@ -1,3 +1,6 @@
+# run coqdoc by default (our CI entrypoint)
+.DEFAULT_GOAL := ci
+
 SRC_DIRS := 'theories'
 EXT_DIRS := 'external'
 ALL_VFILES := $(shell find $(EXT_DIRS) $(SRC_DIRS) -name '*.v' -a '!' -name '*'.\#'*')
@@ -11,7 +14,20 @@ Q:=@
 # extract global arguments for Coq from _CoqProject
 COQPROJECT_ARGS := $(shell sed -E -e '/^\#/d' -e 's/-arg ([^ ]*)/\1/g' _CoqProject)
 
-all: $(VFILES:.v=.vo)
+Makefile.coq: _CoqProject $(ALL_VFILES)
+	$(Q)coq_makefile -f _CoqProject $(ALL_VFILES) -o Makefile.coq -docroot .
+
+include coqdocjs/Makefile.doc
+
+# ensure coqdoc won't run before Makefile.coq is generated
+coqdoc: Makefile.coq
+
+.PHONY: all ci
+
+all:
+	$(MAKE) -f Makefile.coq
+
+ci: Makefile.coq coqdoc
 
 .coqdeps.d: $(ALL_VFILES) _CoqProject
 	@echo "COQDEP $@"
@@ -39,11 +55,8 @@ clean:
 	$(Q)find $(EXT_DIRS) $(SRC_DIRS) \( -name "*.vo" -o -name "*.vo[sk]" \
 		-o -name ".*.aux" -o -name ".*.cache" -o -name "*.glob" \) -delete
 	$(Q)rm -f .lia.cache
+	rm -f Makefile.coq Makefile.coq.conf
 	rm -f .coqdeps.d
-	rm -f Makefile.coq
-	rm -f Makefile.coq.conf
 
 tar:
 	git archive --format=tar.gz -o coq-clutch.tar.gz HEAD
-
-.PHONY: clean zip


### PR DESCRIPTION
Try to generate HTML from coqdocjs, see example on my fork: https://ahuoguo.github.io/clutch/toc.html

The coqdocjs is current on my fork since I need to change some renaming (eg: they render iris anonymous binder `<>` as `≠`). I also added links to external repos like stdpp, coquelicot, iris.

TODO:
- [ ] need to clean up some comments (for example, `coqdoc` reads `<<` in comments as inlining code, etc)
